### PR TITLE
[Feat] Jira Issue 자동 생성 & Git Branch 자동 생성 workflow 추가 

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/issue-form.yml
@@ -1,0 +1,59 @@
+name: '이슈 생성'
+description: 'Repo에 이슈를 생성하며, 생성된 이슈는 Jira와 연동됩니다.'
+title: '이슈 이름을 작성해주세요'
+labels: ['feat']
+
+body:
+  - type: dropdown
+    id: issueType
+    attributes:
+      label: '📌 이슈 유형'
+      options:
+        - feat
+        - init
+        - fix
+        - bug
+        - test
+        - rename
+        - chore
+        - CI
+        - refactor
+        - remove
+        - docs
+        - style
+
+  - type: input
+    id: parentKey
+    attributes:
+      label: '🎟️ 상위 작업 (Ticket Number)'
+      description: '상위 작업의 Ticket Number를 기입해주세요'
+      placeholder: 'PRJ-00'
+    validations:
+      required: true
+
+  - type: input
+    id: branch
+    attributes:
+      label: '🌳 브랜치명 (Branch)'
+      description: '영어로 브랜치명을 작성해주세요'
+    validations:
+      required: true
+
+  - type: input
+    id: description
+    attributes:
+      label: '📝 상세 내용(Description)'
+      description: '이슈에 대해서 간략히 설명해주세요'
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: '✅ 체크리스트(Tasks)'
+      description: '해당 이슈에 대해 필요한 작업목록을 작성해주세요'
+      value: |
+        - [ ] Task1
+        - [ ] Task2
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/issue-form.yml
@@ -16,7 +16,7 @@ body:
         - test
         - rename
         - chore
-        - CI
+        - ci
         - refactor
         - remove
         - docs
@@ -31,16 +31,9 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: branch
-    attributes:
-      label: '🌳 브랜치명 (Branch)'
-      description: '영어로 브랜치명을 작성해주세요'
-    validations:
-      required: true
 
   - type: input
-    id: description
+    id: textarea
     attributes:
       label: '📝 상세 내용(Description)'
       description: '이슈에 대해서 간략히 설명해주세요'

--- a/.github/ISSUE_TEMPLATE/issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/issue-form.yml
@@ -1,13 +1,13 @@
 name: '이슈 생성'
 description: 'Repo에 이슈를 생성하며, 생성된 이슈는 Jira와 연동됩니다.'
 title: '이슈 이름을 작성해주세요'
-labels: ['feat']
 
 body:
   - type: dropdown
     id: issueType
     attributes:
       label: '📌 이슈 유형'
+      description: 'Labels 할당해주세요'
       options:
         - feat
         - init
@@ -27,7 +27,7 @@ body:
     attributes:
       label: '🎟️ 상위 작업 (Ticket Number)'
       description: '상위 작업의 Ticket Number를 기입해주세요'
-      placeholder: 'PRJ-00'
+      placeholder: 'MOONO-00'
     validations:
       required: true
 

--- a/.github/workflows/close-jira-issue.yml
+++ b/.github/workflows/close-jira-issue.yml
@@ -1,0 +1,19 @@
+- name: Login to Jira
+  uses: atlassian/gajira-login@v3
+  env:
+    JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+    JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+    JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+- name: Extract Jira issue key from GitHub issue title
+  id: extract-key
+  run: |
+      ISSUE_TITLE="${{ github.event.issue.title }}"
+      JIRA_KEY=$(echo "$ISSUE_TITLE" | grep -oE '[A-Z]+-[0-9]+')
+      echo "JIRA_KEY=$JIRA_KEY" >> $GITHUB_ENV
+- name: Close Jira issue
+  if: env.JIRA_KEY != ''
+  uses: atlassian/gajira-transition@v3
+  with:
+      issue: ${{ env.JIRA_KEY }}
+      transition: Done

--- a/.github/workflows/close-jira-issue.yml
+++ b/.github/workflows/close-jira-issue.yml
@@ -1,19 +1,28 @@
-- name: Login to Jira
-  uses: atlassian/gajira-login@v3
-  env:
-    JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-    JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-    JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+name: Login to Jira
+on:
+  issues:
+    types:
+      - closed
+jobs:
+  close-jira:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Jira
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
 
-- name: Extract Jira issue key from GitHub issue title
-  id: extract-key
-  run: |
-      ISSUE_TITLE="${{ github.event.issue.title }}"
-      JIRA_KEY=$(echo "$ISSUE_TITLE" | grep -oE '[A-Z]+-[0-9]+')
-      echo "JIRA_KEY=$JIRA_KEY" >> $GITHUB_ENV
-- name: Close Jira issue
-  if: env.JIRA_KEY != ''
-  uses: atlassian/gajira-transition@v3
-  with:
-      issue: ${{ env.JIRA_KEY }}
-      transition: Done
+      - name: Extract Jira issue key from GitHub issue title
+        id: extract-key
+        run: |
+            ISSUE_TITLE="${{ github.event.issue.title }}"
+            JIRA_KEY=$(echo "$ISSUE_TITLE" | grep -oE '[A-Z]+-[0-9]+')
+            echo "JIRA_KEY=$JIRA_KEY" >> $GITHUB_ENV
+      - name: Close Jira issue
+        if: env.JIRA_KEY != ''
+        uses: atlassian/gajira-transition@v3
+        with:
+            issue: ${{ env.JIRA_KEY }}
+            transition: Done

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -1,0 +1,101 @@
+name: Create Jira issue
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  create-issue:
+    name: Create Jira issue
+    runs-on: ubuntu-latest
+
+    steps:
+      # 0. Jira 로그인
+      - name: Login
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+      # 1. develop 브랜치 체크아웃 (개발용 브랜치)
+      - name: Checkout develop code
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      # 2. Issue Form 파서
+      - name: Issue Parser
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/issue-form.yml
+
+      # 3. 라벨 자동 적용
+      - name: Apply GitHub Label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: ${{ steps.issue-parser.outputs.issueparser_issueType }}
+
+      # 4. Markdown → Jira 포맷 변환
+      - name: Convert markdown to Jira Syntax
+        uses: peter-evans/jira2md@v1
+        id: md2jira
+        with:
+          input-text: |
+            ### Github Issue Link
+            - ${{ github.event.issue.html_url }}
+
+            ${{ github.event.issue.body }}
+          mode: md2jira
+
+      # 5. Jira Issue 생성
+      - name: Create Issue
+        id: create
+        uses: atlassian/gajira-create@v3
+        with:
+          project: SKP
+          issuetype: Task
+          summary: '${{ github.event.issue.title }}'
+          description: '${{ steps.md2jira.outputs.output-text }}'
+          fields: |
+            {
+              "parent": {
+                "key": "${{ steps.issue-parser.outputs.issueparser_parentKey }}"
+              },
+              "labels": [
+                "${{ steps.issue-parser.outputs.issueparser_issueType }}"
+              ]
+            }
+
+      - name: Log created issue
+        run: echo "Jira Issue ${{ steps.create.outputs.issue }} created"
+
+      # 6. develop 기반으로 feature 브랜치 생성
+      - name: Create branch with Ticket number
+        run: |
+          ISSUE_NUMBER="${{ steps.create.outputs.issue }}"
+          ISSUE_TITLE="${{ steps.issue-parser.outputs.issueparser_branch }}"
+          ISSUE_TYPE="${{ steps.issue-parser.outputs.issueparser_issueType }}"
+
+          BRANCH_NAME="${ISSUE_TYPE}/${ISSUE_NUMBER}-$(echo ${ISSUE_TITLE} | sed 's/ /-/g')"
+
+          git checkout -b "${BRANCH_NAME}"
+          git push origin "${BRANCH_NAME}"
+
+      # 7. GitHub Issue 제목 업데이트
+      - name: Update issue title
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'update-issue'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: '[${{ steps.create.outputs.issue }}] ${{ github.event.issue.title }}'
+
+      # 8. 댓글로 Jira 링크 달기
+      - name: Add comment with Jira issue link
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-comment'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: 'Jira Issue Created: [${{ steps.create.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create.outputs.issue }})'


### PR DESCRIPTION
# PR 제목
Jira CI 구축으로 이슈 생성, 닫기 작업을 자동화하였습니다. 

## 작업 내용
🔧 주요 기능 (What’s Added)
1) GitHub Issue 생성 → Jira Issue 자동 생성
2) Issue Form 개선 (Issue Template) 
3) develop 기반 Feature 브랜치 자동 생성
issue 생성시 자동 브랜치 만들어집니다. 
{issueType}/{JIRA_ISSUE_KEY}-{issueTitle}
4) Issue 제목 자동 업데이트
기존 Issue 제목을 다음과 같이 자동 변환:
[SKP-123] 원래 이슈 제목
5) GitHub → Jira 연동을 위한 Secrets 사용
JIRA_BASE_URL
JIRA_USER_EMAIL
JIRA_API_TOKEN

🧪 테스트 방법
GitHub Repository에서 새로운 Issue 생성
Issue Form에서 필요한 값 입력
Issue가 생성되면 아래 자동 동작 확인:
Jira Issue 자동 생성
GitHub Issue에 라벨 자동 부착
develop 기반 브랜치 자동 생성 및 push
GitHub Issue 제목 자동 업데이트
Jira 링크 댓글 자동 




## 체크리스트
- [ ] 코드 작성 완료
- [ ] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [ ] 코드 스타일/컨벤션 확인

## 관련 이슈
- #19 

## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용