### PR TITLE
[Feat] 사용량 과금을 조회하는 코드 작성

### DIFF
--- a/src/main/java/org/example/moono_backend/batch/BillingBatch.java
+++ b/src/main/java/org/example/moono_backend/batch/BillingBatch.java
@@ -20,6 +20,7 @@ import org.example.moono_backend.domain.member.MemberCredential;
 import org.example.moono_backend.dto.DiscountInfo;
 import org.example.moono_backend.service.ContractDiscountService;
 import org.example.moono_backend.service.EventDiscountService;
+import org.example.moono_backend.service.PlanDiscountService;
 import org.springframework.batch.core.ChunkListener;
 import org.springframework.batch.core.ItemProcessListener;
 import org.springframework.batch.core.ItemReadListener;
@@ -120,6 +121,7 @@ public class BillingBatch {
             .rowMapper((rs, rowNum) -> new BillingSourceRow(
                 rs.getString("public_info_id"),
                 rs.getInt("base_fee"),
+                rs.getLong("plan_id"),
                 rs.getBoolean("premium_yn"),
                 rs.getInt("term_year"),
                 rs.getTimestamp("contract_created_at").toLocalDateTime(),
@@ -142,6 +144,7 @@ public class BillingBatch {
         pi.id            AS public_info_id,
         p.base_fee       AS base_fee,
         p.premium_yn     AS premium_yn,
+        p.id AS plan_id,
         c.term_year      AS term_year,
         c.created_at     AS contract_created_at,
         ut.call_amount   AS call_amount,
@@ -178,8 +181,8 @@ public class BillingBatch {
     @StepScope
     public ItemProcessor<BillingSourceRow, BillingWriteItem> billingProcessor(
         @Value("#{jobParameters['now']}") String nowParam,
-        MemberPreloadListener memberPreloadListener
-    ) {
+        MemberPreloadListener memberPreloadListener,
+        PlanDiscountService planDiscountService) {
         LocalDateTime now =LocalDateTime.now();
 
         return row -> {
@@ -195,6 +198,9 @@ public class BillingBatch {
             if (birthdayMonthDiscount != null) {
                 discountInfoList.add(birthdayMonthDiscount);
             }
+
+            //요금제 별 정보 조회
+            planDiscountService.calculatePlanDiscounts(row);
 
 
             // TODO: 할인 반영해서 billingFee 계산

--- a/src/main/java/org/example/moono_backend/batch/BillingBatch.java
+++ b/src/main/java/org/example/moono_backend/batch/BillingBatch.java
@@ -130,7 +130,7 @@ public class BillingBatch {
             FROM public_info pi
             JOIN registration r ON r.public_info_id = pi.id
             JOIN plan p         ON p.id = r.plan_id
-            JOIN contract c     ON c.register_id = r.id
+            LEFT OUTER JOIN contract c     ON c.register_id = r.id
     """);
 
         if (lastId != null) {

--- a/src/main/java/org/example/moono_backend/batch/BillingBatch.java
+++ b/src/main/java/org/example/moono_backend/batch/BillingBatch.java
@@ -1,8 +1,11 @@
 package org.example.moono_backend.batch;
 
+import java.sql.Date;
 import java.sql.Types;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -95,27 +98,44 @@ public class BillingBatch {
     public JdbcPagingItemReader<BillingSourceRow> billingSourceReader(
         DataSource dataSource,
         PagingQueryProvider queryProvider,
-        @Value("#{stepExecutionContext['lastId']}") String lastId
+        @Value("#{stepExecutionContext['lastId']}") String lastId,
+        @Value("#{jobParameters['date']}") String dateParam
     ) {
+
+        //sql에서 이해하는 걸로 변경
+        LocalDate usageDate= LocalDate.parse(dateParam);
+        Map<String,Object> params = new HashMap<>();
+        params.put("usageDate", Date.valueOf(usageDate));
+        if (lastId != null) {
+            params.put("lastId", lastId);
+        }
+
+
         return new JdbcPagingItemReaderBuilder<BillingSourceRow>()
             .name("billingSourceReader")
             .dataSource(dataSource)
             .queryProvider(queryProvider)
-            .parameterValues(lastId == null ? Map.of() : Map.of("lastId", lastId))
+            .parameterValues(params)
             .pageSize(CHUNK_SIZE)
             .rowMapper((rs, rowNum) -> new BillingSourceRow(
                 rs.getString("public_info_id"),
                 rs.getInt("base_fee"),
                 rs.getBoolean("premium_yn"),
                 rs.getInt("term_year"),
-                rs.getTimestamp("contract_created_at").toLocalDateTime()
+                rs.getTimestamp("contract_created_at").toLocalDateTime(),
+                rs.getInt("call_amount"),
+                rs.getInt("message_amount"),
+                rs.getInt("data_amount")
             ))
             .build();
     }
 
     @Bean
     @StepScope
-    public PagingQueryProvider pagingQueryProvider(@Value("#{stepExecutionContext['lastId']}") String lastId) {
+    public PagingQueryProvider pagingQueryProvider(
+        @Value("#{stepExecutionContext['lastId']}") String lastId,
+        @Value("#{jobParameters['date']}") String dateParam
+    ) {
         PostgresPagingQueryProvider queryProvider = new PostgresPagingQueryProvider();
         queryProvider.setSelectClause("""
     SELECT
@@ -123,7 +143,10 @@ public class BillingBatch {
         p.base_fee       AS base_fee,
         p.premium_yn     AS premium_yn,
         c.term_year      AS term_year,
-        c.created_at     AS contract_created_at
+        c.created_at     AS contract_created_at,
+        ut.call_amount   AS call_amount,
+        ut.message_amount AS message_amount,
+        ut.data_amount   AS data_amount
     """);
 
         queryProvider.setFromClause("""
@@ -131,10 +154,18 @@ public class BillingBatch {
             JOIN registration r ON r.public_info_id = pi.id
             JOIN plan p         ON p.id = r.plan_id
             LEFT OUTER JOIN contract c     ON c.register_id = r.id
-    """);
+            JOIN usage_time ut  ON ut.public_info_id = pi.id
+   """);
 
         if (lastId != null) {
-            queryProvider.setWhereClause("WHERE pi.id > :lastId");
+            queryProvider.setWhereClause("""
+            WHERE ut.usage_date = :usageDate
+              AND pi.id > :lastId
+        """);
+        } else {
+            queryProvider.setWhereClause("""
+            WHERE ut.usage_date = :usageDate
+        """);
         }
 
         queryProvider.setSortKeys(Map.of("public_info_id", Order.ASCENDING));

--- a/src/main/java/org/example/moono_backend/batch/BillingBatch.java
+++ b/src/main/java/org/example/moono_backend/batch/BillingBatch.java
@@ -18,6 +18,7 @@ import org.example.moono_backend.domain.PayStatus;
 import org.example.moono_backend.domain.SendStatus;
 import org.example.moono_backend.domain.member.MemberCredential;
 import org.example.moono_backend.dto.DiscountInfo;
+import org.example.moono_backend.dto.OverageChargeInfo;
 import org.example.moono_backend.service.ContractDiscountService;
 import org.example.moono_backend.service.EventDiscountService;
 import org.example.moono_backend.service.PlanDiscountService;
@@ -199,8 +200,8 @@ public class BillingBatch {
                 discountInfoList.add(birthdayMonthDiscount);
             }
 
-            //요금제 별 정보 조회
-            planDiscountService.calculatePlanDiscounts(row);
+            //요금제 별 과금 조회
+            List<OverageChargeInfo> overageChargeInfos=planDiscountService.calculatePlanDiscounts(row);
 
 
             // TODO: 할인 반영해서 billingFee 계산

--- a/src/main/java/org/example/moono_backend/batch/BillingSchedule.java
+++ b/src/main/java/org/example/moono_backend/batch/BillingSchedule.java
@@ -1,6 +1,7 @@
 package org.example.moono_backend.batch;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.configuration.JobRegistry;
@@ -13,6 +14,7 @@ import java.util.Date;
 
 @Configuration
 @RequiredArgsConstructor
+@Slf4j
 public class BillingSchedule {
     private final JobLauncher jobLauncher;
     private final JobRegistry jobRegistry;
@@ -20,10 +22,10 @@ public class BillingSchedule {
     // 초 분 시 일 월 요일
     @Scheduled(cron = "0 0 0 1 * *", zone = "Asia/Seoul")
     public void runMonthlyBillingJob() throws Exception {
-        System.out.println("MonthlyBilling Schedule start");
+        log.info("MonthlyBilling Schedule start");
 
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM");
-        String date = dateFormat.format(new Date());
+        String date = dateFormat.format(new Date())+"-01";
 
         JobParameters jobParameters = new JobParametersBuilder()
                 .addString("date", date)

--- a/src/main/java/org/example/moono_backend/batch/dto/BillingSourceRow.java
+++ b/src/main/java/org/example/moono_backend/batch/dto/BillingSourceRow.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 public record BillingSourceRow(
     String publicInfoId,
     Integer baseFee,
+    Long planId,
     Boolean premiumYn,
     Integer termYear,
     LocalDateTime contractCreatedAt,

--- a/src/main/java/org/example/moono_backend/batch/dto/BillingSourceRow.java
+++ b/src/main/java/org/example/moono_backend/batch/dto/BillingSourceRow.java
@@ -7,5 +7,8 @@ public record BillingSourceRow(
     Integer baseFee,
     Boolean premiumYn,
     Integer termYear,
-    LocalDateTime contractCreatedAt
+    LocalDateTime contractCreatedAt,
+    Integer callAmount,
+    Integer messageAmount,
+    Integer dataAmount
 ) {}

--- a/src/main/java/org/example/moono_backend/domain/Plan.java
+++ b/src/main/java/org/example/moono_backend/domain/Plan.java
@@ -26,7 +26,7 @@ public class Plan extends BaseEntity {
     private Integer baseFee;
 
     //기본 제공량
-    private Double basicMobileData;
+    private Integer basicMobileData;
     private Integer basicVoice;
     private Integer basicSms;
 

--- a/src/main/java/org/example/moono_backend/domain/Plan.java
+++ b/src/main/java/org/example/moono_backend/domain/Plan.java
@@ -25,11 +25,15 @@ public class Plan extends BaseEntity {
 
     private Integer baseFee;
 
+    //기본 제공량
     private Double basicMobileData;
-
     private Integer basicVoice;
-
     private Integer basicSms;
+
+    //초과단가
+    private Integer overVoiceUnitFee;
+    private Integer overSmsUnitFee;
+    private Integer overDataUnitFeePerMb;
 
     private Boolean premiumYn;
 

--- a/src/main/java/org/example/moono_backend/dto/OverageChargeInfo.java
+++ b/src/main/java/org/example/moono_backend/dto/OverageChargeInfo.java
@@ -1,0 +1,14 @@
+package org.example.moono_backend.dto;
+
+public record OverageChargeInfo(
+    String code,
+    String displayName,
+    int overAmount,
+    int chargeAmount
+) {
+    public static OverageChargeInfo from(String code, String displayName, int overAmount, int chargeAmount) {
+        return new OverageChargeInfo(code, displayName, overAmount, chargeAmount);
+    }
+
+
+}

--- a/src/main/java/org/example/moono_backend/repository/PlanRepository.java
+++ b/src/main/java/org/example/moono_backend/repository/PlanRepository.java
@@ -1,9 +1,28 @@
 package org.example.moono_backend.repository;
 
+import java.util.List;
 import org.example.moono_backend.domain.Plan;
+import org.example.moono_backend.utils.PlanCacheItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+
+    @Query("""
+        SELECT new org.example.moono_backend.utils.PlanCacheItem(
+            p.id,
+            p.tierId,
+            p.planName,
+            p.baseFee,
+            p.basicMobileData,
+            p.basicVoice,
+            p.basicSms,
+            p.premiumYn,
+            p.dataInfiniteYn
+        )
+        FROM Plan p
+    """)
+    List<PlanCacheItem> findAllForCache();
 }

--- a/src/main/java/org/example/moono_backend/repository/PlanRepository.java
+++ b/src/main/java/org/example/moono_backend/repository/PlanRepository.java
@@ -19,8 +19,11 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
             p.basicMobileData,
             p.basicVoice,
             p.basicSms,
+            p.overVoiceUnitFee,
+            p.overSmsUnitFee,
+            p.overDataUnitFeePerMb,
             p.premiumYn,
-            p.dataInfiniteYn
+            p.dataInfiniteYn    
         )
         FROM Plan p
     """)

--- a/src/main/java/org/example/moono_backend/service/PlanDiscountService.java
+++ b/src/main/java/org/example/moono_backend/service/PlanDiscountService.java
@@ -1,0 +1,72 @@
+package org.example.moono_backend.service;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.example.moono_backend.batch.dto.BillingSourceRow;
+import org.example.moono_backend.dto.OverageChargeInfo;
+import org.example.moono_backend.utils.PlanCache;
+import org.example.moono_backend.utils.PlanCacheItem;
+import org.springframework.stereotype.Service;
+
+/**
+ * 요금제 및 하이브리드 과금에 따른 할인률
+ */
+
+@Service
+@Slf4j
+public class PlanDiscountService {
+
+    public List<OverageChargeInfo> calculatePlanDiscounts(BillingSourceRow row) {
+        List<OverageChargeInfo> overageChargeInfos = new ArrayList<>();
+
+        //캐시에서 요금제를 조회한다
+        PlanCacheItem planCacheItem= PlanCache.INSTANCE.get(row.planId());
+        Integer basicMobileData=planCacheItem.getBasicMobileData();
+        Integer basicVoice=planCacheItem.getBasicVoice();
+        Integer basicSms=planCacheItem.getBasicSms();
+
+
+        //디스크에서 사용량을 조회한다
+        Integer callAmount=row.callAmount();
+        Integer messageAmount=row.messageAmount();
+
+        //데이터 초과량
+        if (!planCacheItem.getDataInfiniteYn()) {
+            //TODO: 데이터 사용량을 double로 바꾸기
+            int overData=calculateOverAmount(row.dataAmount(),basicMobileData);
+
+            if (overData>0) {
+                int charge=overData*planCacheItem.getOverDataUnitFeePerMb();
+                overageChargeInfos.add(OverageChargeInfo.from("OVER_DATA","데이터 초과",overData,charge));
+
+            }
+        }
+        //통화량
+        int overByCall=calculateOverAmount(callAmount,basicVoice);
+        if (overByCall>0){
+            int charge=overByCall* planCacheItem.getOverVoiceUnitFee();
+            overageChargeInfos.add(OverageChargeInfo.from("OVER_VOICE","통화량 초과",overByCall,charge));
+        }
+
+        //메세지량
+        int overByMessage=calculateOverAmount(messageAmount,basicSms);
+
+        if (overByMessage>0){
+            int charge=overByMessage* planCacheItem.getOverSmsUnitFee();
+            overageChargeInfos.add(OverageChargeInfo.from("OVER_SMS","메세지량 초과",overByCall,charge));
+        }
+
+        return overageChargeInfos;
+
+
+    }
+
+
+    private int calculateOverAmount(Integer usageAmount, Integer givenAmount) {
+        return Math.max(0, usageAmount - givenAmount);
+    }
+
+
+}

--- a/src/main/java/org/example/moono_backend/utils/PlanCache.java
+++ b/src/main/java/org/example/moono_backend/utils/PlanCache.java
@@ -1,0 +1,22 @@
+package org.example.moono_backend.utils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public enum PlanCache {
+
+    INSTANCE;
+
+    private final Map<Long, PlanCacheItem> cache = new HashMap<>();
+
+    public void putAll(List<PlanCacheItem> plans) {
+        for (PlanCacheItem plan : plans) {
+            cache.put(plan.getId(), plan);
+        }
+    }
+
+    public PlanCacheItem get(Long planId) {
+        return cache.get(planId);
+    }
+}

--- a/src/main/java/org/example/moono_backend/utils/PlanCacheInitializer.java
+++ b/src/main/java/org/example/moono_backend/utils/PlanCacheInitializer.java
@@ -1,0 +1,20 @@
+package org.example.moono_backend.utils;
+
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.example.moono_backend.repository.PlanRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlanCacheInitializer {
+
+    private final PlanRepository planRepository;
+
+    @PostConstruct
+    public void init() {
+        List<PlanCacheItem> plans = planRepository.findAllForCache();
+        PlanCache.INSTANCE.putAll(plans);
+    }
+}

--- a/src/main/java/org/example/moono_backend/utils/PlanCacheItem.java
+++ b/src/main/java/org/example/moono_backend/utils/PlanCacheItem.java
@@ -12,7 +12,7 @@ public class PlanCacheItem {
     private final String planName;
     private final Integer baseFee;
 
-    private final Double basicMobileData;
+    private final Integer basicMobileData;
     private final Integer basicVoice;
     private final Integer basicSms;
 

--- a/src/main/java/org/example/moono_backend/utils/PlanCacheItem.java
+++ b/src/main/java/org/example/moono_backend/utils/PlanCacheItem.java
@@ -1,0 +1,19 @@
+package org.example.moono_backend.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PlanCacheItem {
+
+    private final Long id;
+    private final Long tierId;
+    private final String planName;
+    private final Integer baseFee;
+    private final Double basicMobileData;
+    private final Integer basicVoice;
+    private final Integer basicSms;
+    private final Boolean premiumYn;
+    private final Boolean dataInfiniteYn;
+}

--- a/src/main/java/org/example/moono_backend/utils/PlanCacheItem.java
+++ b/src/main/java/org/example/moono_backend/utils/PlanCacheItem.java
@@ -11,9 +11,16 @@ public class PlanCacheItem {
     private final Long tierId;
     private final String planName;
     private final Integer baseFee;
+
     private final Double basicMobileData;
     private final Integer basicVoice;
     private final Integer basicSms;
+
+    //초과단가
+    private Integer overVoiceUnitFee;
+    private Integer overSmsUnitFee;
+    private Integer overDataUnitFeePerMb;
+
     private final Boolean premiumYn;
     private final Boolean dataInfiniteYn;
 }

--- a/src/test/java/org/example/moono_backend/BillingSourceReaderOnlyTest.java
+++ b/src/test/java/org/example/moono_backend/BillingSourceReaderOnlyTest.java
@@ -2,7 +2,9 @@ package org.example.moono_backend;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import javax.sql.DataSource;
@@ -30,6 +32,8 @@ class BillingSourceReaderOnlyTest {
     private JdbcTemplate jdbcTemplate;
     private BillingBatch billingBatch;
 
+    static final String DATE_PARAM="2025-10-10";
+    static final String LAST_ID="A000";
     @BeforeEach
     void setUp() {
         this.context = new AnnotationConfigApplicationContext(TestDataSourceConfiguration.class);
@@ -50,10 +54,10 @@ class BillingSourceReaderOnlyTest {
     void lastId가_null이면_첫번째_청크가_읽힌다() throws Exception {
         // given
         String lastId=null;
-        PagingQueryProvider queryProvider = billingBatch.pagingQueryProvider(lastId);
+        PagingQueryProvider queryProvider = billingBatch.pagingQueryProvider(lastId,DATE_PARAM);
 
         JdbcPagingItemReader<BillingSourceRow> reader =
-            billingBatch.billingSourceReader(dataSource, queryProvider, lastId);
+            billingBatch.billingSourceReader(dataSource, queryProvider, lastId,DATE_PARAM);
 
         reader.afterPropertiesSet();
         reader.open(new ExecutionContext());
@@ -73,11 +77,10 @@ class BillingSourceReaderOnlyTest {
     @Test
     void lastId보다_큰_public_info만_정상적으로_조인되어_읽힌다() throws Exception {
         // given
-        String lastId="A000";
-        PagingQueryProvider queryProvider = billingBatch.pagingQueryProvider(lastId);
+        PagingQueryProvider queryProvider = billingBatch.pagingQueryProvider(LAST_ID,DATE_PARAM);
 
         JdbcPagingItemReader<BillingSourceRow> reader =
-            billingBatch.billingSourceReader(dataSource, queryProvider, lastId);
+            billingBatch.billingSourceReader(dataSource, queryProvider, LAST_ID,DATE_PARAM);
 
         reader.afterPropertiesSet();
         reader.open(new ExecutionContext());
@@ -96,6 +99,9 @@ class BillingSourceReaderOnlyTest {
         assertThat(r1.baseFee()).isEqualTo(10000);
         assertThat(r1.premiumYn()).isTrue();
         assertThat(r1.termYear()).isEqualTo(2);
+        assertThat(r1.callAmount()).isEqualTo(200);
+        assertThat(r1.messageAmount()).isEqualTo(20);
+        assertThat(r1.dataAmount()).isEqualTo(10000);
         assertThat(r1.contractCreatedAt()).isEqualTo(LocalDateTime.of(2025, 1, 1, 0, 0));
 
         assertThat(r2.publicInfoId()).isEqualTo("B001");
@@ -104,6 +110,8 @@ class BillingSourceReaderOnlyTest {
         assertThat(r2.termYear()).isEqualTo(1);
         assertThat(r2.contractCreatedAt()).isEqualTo(LocalDateTime.of(2025, 6, 1, 0, 0));
     }
+
+
 
     private void seed() {
         // public_info
@@ -132,6 +140,21 @@ class BillingSourceReaderOnlyTest {
         jdbcTemplate.update(
             "INSERT INTO contract (id, register_id, term_year, created_at) VALUES (?, ?, ?, ?)",
             203L, 103L, 1, Timestamp.valueOf(LocalDateTime.of(2025, 6, 1, 0, 0))
+        );
+
+        LocalDate d1 = LocalDate.of(2025, 10, 10);
+
+        jdbcTemplate.update(
+            "INSERT INTO usage_time (public_info_id, usage_date, call_amount, message_amount, data_amount) VALUES (?, ?, ?, ?, ?)",
+            "A000", Date.valueOf(d1), 100, 10, 5000
+        );
+        jdbcTemplate.update(
+            "INSERT INTO usage_time (public_info_id, usage_date, call_amount, message_amount, data_amount) VALUES (?, ?, ?, ?, ?)",
+            "A001", Date.valueOf(d1), 200, 20, 10000
+        );
+        jdbcTemplate.update(
+            "INSERT INTO usage_time (public_info_id, usage_date, call_amount, message_amount, data_amount) VALUES (?, ?, ?, ?, ?)",
+            "B001", Date.valueOf(d1), 300, 30, 15000
         );
     }
 
@@ -172,6 +195,15 @@ class BillingSourceReaderOnlyTest {
                     term_year   INT NOT NULL,
                     created_at  TIMESTAMP NOT NULL
                 );
+                
+                  CREATE TABLE usage_time (
+                      public_info_id VARCHAR(255) NOT NULL,
+                      usage_date     DATE NOT NULL,
+                      call_amount    INT NOT NULL,
+                      message_amount INT NOT NULL,
+                      data_amount    INT NOT NULL,
+                      CONSTRAINT pk_usage_time PRIMARY KEY (public_info_id, usage_date)
+                                );
                 """;
 
             DataSourceInitializer init = new DataSourceInitializer();


### PR DESCRIPTION
## 🍀 이슈 번호
- #49 

## 작업 내용
<h3>요금제 정책을 캐시로 이전</h3>
DB I/O를 줄여야 하는 상황에서, 현재 요금제가 15개로 고정되어 HashMap 캐시로 올려도 괜찮다고 판단하였습니다. 
추후 요금제가 추가되면 Global Cache를 도입할 예정입니다

## 체크리스트
- [ ] 코드 작성 완료
- [ ] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [ ] 코드 스타일/컨벤션 확인


## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용