### PR TITLE
[Fix] 배치 실행 시 네이티브 쿼리가 작동하지 않는 문제 해결

### DIFF
--- a/src/main/java/org/example/moono_backend/batch/billing/BillingBatch.java
+++ b/src/main/java/org/example/moono_backend/batch/billing/BillingBatch.java
@@ -142,39 +142,47 @@ public class BillingBatch {
             @Value("#{stepExecutionContext['lastId']}") String lastId,
             @Value("#{jobParameters['date']}") String dateParam) {
         PostgresPagingQueryProvider queryProvider = new PostgresPagingQueryProvider();
+
         queryProvider.setSelectClause("""
-                SELECT
-                    pi.id            AS public_info_id,
-                    p.base_fee       AS base_fee,
-                    p.premium_yn     AS premium_yn,
-                    p.id AS plan_id,
-                    c.term_year      AS term_year,
-                    c.created_at     AS contract_created_at,
-                    ut.call_amount   AS call_amount,
-                    ut.message_amount AS message_amount,
-                    ut.data_amount   AS data_amount
-                """);
+    SELECT
+    t.sort_id AS sort_id,
+        t.public_info_id        AS public_info_id,
+        t.base_fee              AS base_fee,
+        t.premium_yn            AS premium_yn,
+        t.plan_id               AS plan_id,
+        t.term_year             AS term_year,
+        t.contract_created_at   AS contract_created_at,
+        t.call_amount           AS call_amount,
+        t.message_amount        AS message_amount,
+        t.data_amount           AS data_amount
+""");
 
         queryProvider.setFromClause("""
-                         FROM public_info pi
-                         JOIN registration r ON r.public_info_id = pi.id
-                         JOIN plan p         ON p.id = r.plan_id
-                         LEFT OUTER JOIN contract c     ON c.register_id = r.id
-                         JOIN usage_time ut  ON ut.public_info_id = pi.id
-                """);
-
+    FROM (
+        SELECT
+            pi.id               AS sort_id,
+            pi.id               AS public_info_id,
+            p.base_fee          AS base_fee,
+            p.premium_yn        AS premium_yn,
+            p.id                AS plan_id,
+            c.term_year         AS term_year,
+            c.created_at        AS contract_created_at,
+            ut.call_amount      AS call_amount,
+            ut.message_amount   AS message_amount,
+            ut.data_amount      AS data_amount
+        FROM public_info pi
+        JOIN registration r ON r.public_info_id = pi.id
+        JOIN plan p         ON p.id = r.plan_id
+        LEFT JOIN contract c ON c.register_id = r.id
+        JOIN usage_time ut  ON ut.public_info_id = pi.id
+        WHERE ut.usage_date = :usageDate
+    ) t
+""");
         if (lastId != null) {
-            queryProvider.setWhereClause("""
-                        WHERE ut.usage_date = :usageDate
-                          AND pi.id > :lastId
-                    """);
-        } else {
-            queryProvider.setWhereClause("""
-                        WHERE ut.usage_date = :usageDate
-                    """);
+            queryProvider.setWhereClause("WHERE sort_id > :lastId");
         }
+        queryProvider.setSortKeys(Map.of("sort_id", Order.ASCENDING));
 
-        queryProvider.setSortKeys(Map.of("public_info_id", Order.ASCENDING));
 
         return queryProvider;
     }
@@ -206,7 +214,6 @@ public class BillingBatch {
 
             // 요금제 별 과금 조회
             List<OverageChargeInfo> overageChargeInfos = planDiscountService.calculatePlanDiscounts(row);
-
             // 할인 금액 합산
             int totalDiscount = discountInfoList.stream()
                     .mapToInt(DiscountInfo::discountAmount)

--- a/src/test/java/org/example/moono_backend/BillingSourceReaderOnlyTest.java
+++ b/src/test/java/org/example/moono_backend/BillingSourceReaderOnlyTest.java
@@ -9,8 +9,9 @@ import java.time.LocalDateTime;
 
 import javax.sql.DataSource;
 
-import org.example.moono_backend.batch.BillingBatch;
-import org.example.moono_backend.batch.dto.BillingSourceRow;
+
+import org.example.moono_backend.batch.billing.BillingBatch;
+import org.example.moono_backend.batch.billing.dto.BillingSourceRow;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,7 +96,9 @@ class BillingSourceReaderOnlyTest {
         assertThat(r2).isNotNull();
         assertThat(r3).isNull();
 
-        assertThat(r1.publicInfoId()).isEqualTo("A001");
+            int a=0;
+            Integer aa=Integer.valueOf(a);
+       assertThat(r1.publicInfoId()).isEqualTo("A001");
         assertThat(r1.baseFee()).isEqualTo(10000);
         assertThat(r1.premiumYn()).isTrue();
         assertThat(r1.termYear()).isEqualTo(2);

--- a/src/test/java/org/example/moono_backend/BillingSourceReaderOnlyTest.java
+++ b/src/test/java/org/example/moono_backend/BillingSourceReaderOnlyTest.java
@@ -96,9 +96,7 @@ class BillingSourceReaderOnlyTest {
         assertThat(r2).isNotNull();
         assertThat(r3).isNull();
 
-            int a=0;
-            Integer aa=Integer.valueOf(a);
-       assertThat(r1.publicInfoId()).isEqualTo("A001");
+        assertThat(r1.publicInfoId()).isEqualTo("A001");
         assertThat(r1.baseFee()).isEqualTo(10000);
         assertThat(r1.premiumYn()).isTrue();
         assertThat(r1.termYear()).isEqualTo(2);


### PR DESCRIPTION
## 🍀 이슈 번호
#61 

## 작업 내용
ResultSet과 sortKey가 충돌하여 sortKey를 서브쿼리로 뽑아 사용하게 수정하였습니다

## 체크리스트
- [ ] 코드 작성 완료
- [ ] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [ ] 코드 스타일/컨벤션 확인


## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용