### PR TITLE
[MOONO-55] 발송에 필요한 Repo 생성 

### DIFF
--- a/src/main/java/org/example/moono_backend/repository/BillingRepository.java
+++ b/src/main/java/org/example/moono_backend/repository/BillingRepository.java
@@ -1,0 +1,30 @@
+package org.example.moono_backend.repository;
+
+import org.example.moono_backend.domain.Billing;
+import org.example.moono_backend.domain.SendStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Billing 엔티티에 대한 접근 계층
+ *
+ * - billingId로 Billing 조회
+ * - publicInfoId로 Billing 조회
+ * - SendStatus 업데이트를 위한 엔티티 조회
+ */
+@Repository
+public interface BillingRepository extends JpaRepository<Billing, Long> {
+
+    /**
+     * publicInfoId로 Billing 조회
+     * @param publicInfoId 공개 정보 ID
+     * @param sendStatus 발송 상태
+     * @return Optional<Billing>
+     */
+    List<Billing> findByPublicInfoIdAndSendStatus(
+            String publicInfoId
+            , SendStatus sendStatus);
+}

--- a/src/main/java/org/example/moono_backend/repository/EmailFailLogRepository.java
+++ b/src/main/java/org/example/moono_backend/repository/EmailFailLogRepository.java
@@ -1,0 +1,24 @@
+package org.example.moono_backend.repository;
+
+import org.example.moono_backend.domain.EmailFailLog;
+import org.example.moono_backend.domain.SmsSendStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * - 이메일 발송 실패시 SMS 전송을 위한 로그 저장
+ */
+@Repository
+public interface EmailFailLogRepository extends JpaRepository<EmailFailLog, Long> {
+    /**
+     * sms 상태로 실패 로그 조회
+     *
+     * 전체 사용자 중 sms 발송 대기 중 로그를 조회할때 사용
+     *
+     * @param smsSendStatus
+     * @return List<EmailFailLog>
+     */
+    List<EmailFailLog> findBySmsStatus(SmsSendStatus smsSendStatus);
+}

--- a/src/main/java/org/example/moono_backend/repository/UserDndPolicyRepository.java
+++ b/src/main/java/org/example/moono_backend/repository/UserDndPolicyRepository.java
@@ -1,0 +1,44 @@
+package org.example.moono_backend.repository;
+
+import org.example.moono_backend.domain.member.UserDndPolicy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserDndPolicyRepository extends JpaRepository<UserDndPolicy, Long> {
+
+
+    /**
+     * publicInfoId로 사용자의 모든 금칙 시간 정책 조회
+     * @param publicInfoId
+     * @return List<UserDndPolicy> 사용자의 모든 정책 목록
+     */
+    List<UserDndPolicy> findByPublicInfoId(String publicInfoId);
+
+    /**
+     * 발송일별 정책 조회
+     *
+     * 이 메서드는 특정 발송일(15, 21일)에 대한 정책만 조회함
+     *
+     * @param publicInfoId
+     * @param sendDay
+     * @return Optional<UserDndPolicy>
+     */
+    Optional<UserDndPolicy> findByPublicInfoIdAndSendDay(String publicInfoId, String sendDay);
+
+    /**
+     * publicInfoId, sendDay, isDndActive로 활성화된 정책만 조회
+     *
+     * 금칙 시간이 활성화된 정책만 조회하고 싶을때 사용함
+     * @param publicInfoId
+     * @param sendDay
+     * @param isDndActive
+     * @return Optional<UserDndPolicy>
+     */
+    Optional<UserDndPolicy> findByPublicInfoIdAndSendDayAndIsDndActive(
+            String publicInfoId, String sendDay, boolean isDndActive
+    );
+}


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #86 

## 작업 내용

### 1. BillingRepository: 발송 상태 기반 정합성 관리

- findByPublicInfoIdAndSendStatus: 특정 사용자의 청구 데이터 중 특정 상태(예: CREATED, SEND_PENDING)에 있는 레코드를 조회합니다.

- 활용: Consumer가 메시지를 수신했을 때, 중복 발송을 방지하기 위한 멱등성 검사 및 현재 상태 확인에 사용됩니다.

### 2. UserDndPolicyRepository: 개인화된 금칙 시간 조회

- findByPublicInfoIdAndSendDayAndIsDndActive: 사용자의 고유 ID와 특정 발송일(15, 21일), 그리고 Dnd 활성화 여부를 복합적으로 체크하여 정책을 조회합니다.

- 활용: 설계 원칙 3번에 따라 Consumer 수신 시점의 실시간 시간 판단을 위해 유저별 dnd_start, dnd_end 값을 정확히 가져오는 역할을 수행합니다.

### 3. EmailFailLogRepository: 발송 완결성 보장을 위한 Fallback 관리

- findBySmsStatus: 이메일 발송 실패 후 SMS 전환 대기 중인(PENDING) 로그를 일괄 조회합니다.

- 활용: 이메일이 실패한 건들에 대해 관리자가 수동으로 SMS를 재처리하거나, 시스템이 자동으로 미발송 SMS를 추적할 때 사용됩니다.

## 체크리스트
- [ ] 코드 작성 완료
- [ ] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [ ] 코드 스타일/컨벤션 확인


## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용