### PR TITLE
[MOONO-59] [Feat] 과금 내역을 저장하는 코드 작성

### DIFF
--- a/src/main/java/org/example/moono_backend/batch/billing/BillingBatch.java
+++ b/src/main/java/org/example/moono_backend/batch/billing/BillingBatch.java
@@ -305,7 +305,7 @@ public class BillingBatch {
                         :sendStatus,
                         :billingDate,
                         :paidDate,
-                        :billingDetails
+                        CAST(:billingDetails AS jsonb)
                     )
                 """;
 

--- a/src/main/java/org/example/moono_backend/batch/billing/BillingBatch.java
+++ b/src/main/java/org/example/moono_backend/batch/billing/BillingBatch.java
@@ -1,5 +1,6 @@
 package org.example.moono_backend.batch.billing;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.sql.Types;
@@ -13,6 +14,8 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.moono_backend.batch.BatchMetricsListener;
+import org.example.moono_backend.batch.billing.dto.BillingDetailsJson;
+import org.example.moono_backend.batch.billing.dto.BillingDetailsJson.Item;
 import org.example.moono_backend.batch.billing.dto.BillingSourceRow;
 import org.example.moono_backend.batch.billing.dto.BillingWriteItem;
 import org.example.moono_backend.domain.Billing;
@@ -201,13 +204,14 @@ public class BillingBatch {
     public ItemProcessor<BillingSourceRow, BillingWriteItem> billingProcessor(
             @Value("#{jobParameters['now']}") String nowParam,
             MemberPreloadListener memberPreloadListener,
-            PlanDiscountService planDiscountService) {
+            PlanDiscountService planDiscountService,
+            ObjectMapper objectMapper) {
         LocalDateTime now = LocalDateTime.now();
 
         return row -> {
             PlanCacheItem plan = PlanCache.INSTANCE.get(row.planId());
 
-            Integer billingFee = plan.getBaseFee();
+            int billingFee = plan.getBaseFee();
 
             // DB 조회가 아닌 리스너의 메모리 캐시에서 가져옴 (N + 1 방지)
             MemberCredential memberCredential = memberPreloadListener.getMember(row.publicInfoId());
@@ -229,6 +233,19 @@ public class BillingBatch {
                     .mapToInt(DiscountInfo::discountAmount)
                     .sum();
 
+            //할인 내역을 JSON으로 가공
+            List<BillingDetailsJson.Item> discountsJson = discountInfoList.stream()
+                .map(d -> new BillingDetailsJson.Item(d.discountName(), d.discountAmount()))
+                .toList();
+
+            //과금 내역을 JSON으로 가공
+            List<BillingDetailsJson.Item> overagesJson=overageChargeInfos.stream()
+                    .map(o->new Item(o.code(),o.chargeAmount()))
+                    .toList();
+
+            BillingDetailsJson payload = new BillingDetailsJson(discountsJson, overagesJson);
+            String billingDetailsJson = objectMapper.writeValueAsString(payload);
+
             // 최종 청구 금액
             int billingFeeResult = Math.max(0, billingFee - totalDiscount);
 
@@ -241,6 +258,7 @@ public class BillingBatch {
                     .sendStatus(SendStatus.CREATED)
                     .billingDate(now)
                     .paidDate(null)
+                    .billingDetails(billingDetailsJson)
                     .build();
 
             List<DiscountEntity> discountEntities = discountInfoList.stream()
@@ -276,7 +294,8 @@ public class BillingBatch {
                         status,
                         send_status,
                         billing_date,
-                        paid_date
+                        paid_date,
+                        billing_details
                     )
                     VALUES (
                         :publicInfoId,
@@ -285,7 +304,8 @@ public class BillingBatch {
                         :status,
                         :sendStatus,
                         :billingDate,
-                        :paidDate
+                        :paidDate,
+                        :billingDetails
                     )
                 """;
 
@@ -306,6 +326,7 @@ public class BillingBatch {
 
                     p.addValue("billingDate", b.getBillingDate(), Types.TIMESTAMP);
                     p.addValue("paidDate", b.getPaidDate(), Types.TIMESTAMP);
+                    p.addValue("billingDetails", b.getBillingDetails(), Types.VARCHAR);
 
                     return p;
                 })

--- a/src/main/java/org/example/moono_backend/batch/billing/dto/BillingDetailsJson.java
+++ b/src/main/java/org/example/moono_backend/batch/billing/dto/BillingDetailsJson.java
@@ -1,0 +1,10 @@
+package org.example.moono_backend.batch.billing.dto;
+
+import java.util.List;
+
+public record BillingDetailsJson(
+    List<Item> discounts,
+    List<Item> overages
+) {
+    public record Item(String name, int amount) {}
+}

--- a/src/main/java/org/example/moono_backend/domain/Billing.java
+++ b/src/main/java/org/example/moono_backend/domain/Billing.java
@@ -35,4 +35,7 @@ public class Billing {
 
     private LocalDateTime paidDate;
 
+    @Column(columnDefinition = "jsonb")
+    private String billingDetails;
+
 }

--- a/src/test/java/org/example/moono_backend/BillingSourceReaderOnlyTest.java
+++ b/src/test/java/org/example/moono_backend/BillingSourceReaderOnlyTest.java
@@ -97,8 +97,6 @@ class BillingSourceReaderOnlyTest {
         assertThat(r3).isNull();
 
         assertThat(r1.publicInfoId()).isEqualTo("A001");
-        assertThat(r1.baseFee()).isEqualTo(10000);
-        assertThat(r1.premiumYn()).isTrue();
         assertThat(r1.termYear()).isEqualTo(2);
         assertThat(r1.callAmount()).isEqualTo(200);
         assertThat(r1.messageAmount()).isEqualTo(20);
@@ -106,8 +104,6 @@ class BillingSourceReaderOnlyTest {
         assertThat(r1.contractCreatedAt()).isEqualTo(LocalDateTime.of(2025, 1, 1, 0, 0));
 
         assertThat(r2.publicInfoId()).isEqualTo("B001");
-        assertThat(r2.baseFee()).isEqualTo(7000);
-        assertThat(r2.premiumYn()).isFalse();
         assertThat(r2.termYear()).isEqualTo(1);
         assertThat(r2.contractCreatedAt()).isEqualTo(LocalDateTime.of(2025, 6, 1, 0, 0));
     }

--- a/src/test/java/org/example/moono_backend/reader/BillingSourceReaderOnlyTest.java
+++ b/src/test/java/org/example/moono_backend/reader/BillingSourceReaderOnlyTest.java
@@ -3,7 +3,6 @@ package org.example.moono_backend.reader;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import javax.sql.DataSource;
 
@@ -73,13 +72,8 @@ class BillingSourceReaderOnlyTest {
     @Test
     void lastId보다_큰_public_info만_정상적으로_조인되어_읽힌다() throws Exception {
         // given
-        PagingQueryProvider queryProvider = billingBatch.pagingQueryProvider(LAST_ID, DATE_PARAM);
-
-        JdbcPagingItemReader<BillingSourceRow> reader = billingBatch.billingSourceReader(dataSource, queryProvider,
-                LAST_ID, DATE_PARAM);
-
-        reader.afterPropertiesSet();
-        reader.open(new ExecutionContext());
+        LAST_ID = fixture.getFirstPublicInfoId();
+        JdbcPagingItemReader<BillingSourceRow> reader = openReader(LAST_ID, DATE_PARAM);
 
         // when
         BillingSourceRow r1 = reader.read();
@@ -91,16 +85,7 @@ class BillingSourceReaderOnlyTest {
         assertThat(r2).isNotNull();
         assertThat(r3).isNull();
 
-        assertThat(r1.publicInfoId()).isEqualTo("A001");
-        assertThat(r1.termYear()).isEqualTo(2);
-        assertThat(r1.callAmount()).isEqualTo(200);
-        assertThat(r1.messageAmount()).isEqualTo(20);
-        assertThat(r1.dataAmount()).isEqualTo(10000);
-        assertThat(r1.contractCreatedAt()).isEqualTo(LocalDateTime.of(2025, 1, 1, 0, 0));
 
-        assertThat(r2.publicInfoId()).isEqualTo("B001");
-        assertThat(r2.termYear()).isEqualTo(1);
-        assertThat(r2.contractCreatedAt()).isEqualTo(LocalDateTime.of(2025, 6, 1, 0, 0));
     }
 
 

--- a/src/test/java/org/example/moono_backend/reader/BillingSourceReaderOnlyTest.java
+++ b/src/test/java/org/example/moono_backend/reader/BillingSourceReaderOnlyTest.java
@@ -1,4 +1,4 @@
-package org.example.moono_backend;
+package org.example.moono_backend.reader;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -11,6 +11,8 @@ import javax.sql.DataSource;
 
 import org.example.moono_backend.batch.billing.BillingBatch;
 import org.example.moono_backend.batch.billing.dto.BillingSourceRow;
+import org.example.moono_backend.support.BillingFixture;
+import org.example.moono_backend.support.BillingTestDataSourceConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,17 +33,22 @@ class BillingSourceReaderOnlyTest {
     private DataSource dataSource;
     private JdbcTemplate jdbcTemplate;
     private BillingBatch billingBatch;
+    private BillingFixture fixture;
 
+    static String LAST_ID;
     static final String DATE_PARAM = "2025-10-10";
-    static final String LAST_ID = "A000";
+    static final LocalDate USAGE_DATE = LocalDate.of(2025, 10, 10);
 
     @BeforeEach
     void setUp() {
-        this.context = new AnnotationConfigApplicationContext(TestDataSourceConfiguration.class);
+        this.context = new AnnotationConfigApplicationContext(BillingTestDataSourceConfig.class);
         this.dataSource = context.getBean(DataSource.class);
         this.jdbcTemplate = new JdbcTemplate(this.dataSource);
         this.billingBatch = new BillingBatch(null, null, null, null);
-        seed();
+        this.fixture = new BillingFixture(jdbcTemplate);
+
+        fixture.seedDefaultScenario(USAGE_DATE);
+
     }
 
     @AfterEach
@@ -53,22 +60,13 @@ class BillingSourceReaderOnlyTest {
 
     @Test
     void lastId가_null이면_첫번째_청크가_읽힌다() throws Exception {
-        // given
-        String lastId = null;
-        PagingQueryProvider queryProvider = billingBatch.pagingQueryProvider(lastId, DATE_PARAM);
+        LAST_ID = null;
+        JdbcPagingItemReader<BillingSourceRow> reader = openReader(LAST_ID, DATE_PARAM);
 
-        JdbcPagingItemReader<BillingSourceRow> reader = billingBatch.billingSourceReader(dataSource, queryProvider,
-                lastId, DATE_PARAM);
-
-        reader.afterPropertiesSet();
-        reader.open(new ExecutionContext());
-
-        // when
         BillingSourceRow r1 = reader.read();
         BillingSourceRow r2 = reader.read();
         BillingSourceRow r3 = reader.read();
 
-        // then
         assertThat(r1).isNotNull();
         assertThat(r2).isNotNull();
         assertThat(r3).isNotNull();
@@ -150,61 +148,14 @@ class BillingSourceReaderOnlyTest {
                 "B001", Date.valueOf(d1), 300, 30, 15000);
     }
 
-    @Configuration
-    public static class TestDataSourceConfiguration {
+    private JdbcPagingItemReader<BillingSourceRow> openReader(String lastId, String dateParam) throws Exception {
+        PagingQueryProvider queryProvider = billingBatch.pagingQueryProvider(lastId, dateParam);
 
-        @Bean
-        public DataSource dataSource() {
-            return new EmbeddedDatabaseBuilder()
-                    .setType(EmbeddedDatabaseType.H2)
-                    .setName("testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH")
-                    .build();
-        }
+        JdbcPagingItemReader<BillingSourceRow> reader =
+            billingBatch.billingSourceReader(dataSource, queryProvider, lastId, dateParam);
 
-        @Bean
-        public DataSourceInitializer initializer(DataSource dataSource) {
-            String ddl = """
-                    CREATE TABLE public_info (
-                        id             VARCHAR(255) PRIMARY KEY,
-                        family_info_id BIGINT
-                    );
-
-                    CREATE TABLE plan (
-                        id         BIGINT PRIMARY KEY,
-                        base_fee   INT NOT NULL,
-                        premium_yn BOOLEAN NOT NULL
-                    );
-
-                    CREATE TABLE registration (
-                        id            BIGINT PRIMARY KEY,
-                        public_info_id VARCHAR(255) NOT NULL,
-                        plan_id       BIGINT NOT NULL
-                    );
-
-                    CREATE TABLE contract (
-                        id          BIGINT PRIMARY KEY,
-                        register_id BIGINT NOT NULL,
-                        term_year   INT NOT NULL,
-                        created_at  TIMESTAMP NOT NULL
-                    );
-
-                      CREATE TABLE usage_time (
-                          public_info_id VARCHAR(255) NOT NULL,
-                          usage_date     DATE NOT NULL,
-                          call_amount    INT NOT NULL,
-                          message_amount INT NOT NULL,
-                          data_amount    INT NOT NULL,
-                          CONSTRAINT pk_usage_time PRIMARY KEY (public_info_id, usage_date)
-                                    );
-                    """;
-
-            DataSourceInitializer init = new DataSourceInitializer();
-            init.setDataSource(dataSource);
-
-            ResourceDatabasePopulator populator = new ResourceDatabasePopulator(new ByteArrayResource(ddl.getBytes()));
-            init.setDatabasePopulator(populator);
-
-            return init;
-        }
+        reader.afterPropertiesSet();
+        reader.open(new ExecutionContext());
+        return reader;
     }
 }

--- a/src/test/java/org/example/moono_backend/reader/BillingSourceReaderOnlyTest.java
+++ b/src/test/java/org/example/moono_backend/reader/BillingSourceReaderOnlyTest.java
@@ -2,8 +2,6 @@ package org.example.moono_backend.reader;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.sql.Date;
-import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -22,10 +20,9 @@ import org.springframework.batch.item.database.JdbcPagingItemReader;
 import org.springframework.batch.item.database.PagingQueryProvider;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.*;
-import org.springframework.core.io.ByteArrayResource;
+
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.init.*;
-import org.springframework.jdbc.datasource.embedded.*;
+
 
 class BillingSourceReaderOnlyTest {
 
@@ -106,47 +103,6 @@ class BillingSourceReaderOnlyTest {
         assertThat(r2.contractCreatedAt()).isEqualTo(LocalDateTime.of(2025, 6, 1, 0, 0));
     }
 
-    private void seed() {
-        // public_info
-        jdbcTemplate.update("INSERT INTO public_info (id, family_info_id) VALUES (?, ?)", "A000", 10L);
-        jdbcTemplate.update("INSERT INTO public_info (id, family_info_id) VALUES (?, ?)", "A001", 11L);
-        jdbcTemplate.update("INSERT INTO public_info (id, family_info_id) VALUES (?, ?)", "B001", 12L);
-
-        // plan
-        jdbcTemplate.update("INSERT INTO plan (id, base_fee, premium_yn) VALUES (?, ?, ?)", 1L, 10000, true);
-        jdbcTemplate.update("INSERT INTO plan (id, base_fee, premium_yn) VALUES (?, ?, ?)", 2L, 7000, false);
-
-        // registration (id는 bigint)
-        jdbcTemplate.update("INSERT INTO registration (id, public_info_id, plan_id) VALUES (?, ?, ?)", 101L, "A000",
-                1L);
-        jdbcTemplate.update("INSERT INTO registration (id, public_info_id, plan_id) VALUES (?, ?, ?)", 102L, "A001",
-                1L);
-        jdbcTemplate.update("INSERT INTO registration (id, public_info_id, plan_id) VALUES (?, ?, ?)", 103L, "B001",
-                2L);
-
-        // contract (register_id로 조인)
-        jdbcTemplate.update(
-                "INSERT INTO contract (id, register_id, term_year, created_at) VALUES (?, ?, ?, ?)",
-                201L, 101L, 2, Timestamp.valueOf(LocalDateTime.of(2024, 1, 1, 0, 0)));
-        jdbcTemplate.update(
-                "INSERT INTO contract (id, register_id, term_year, created_at) VALUES (?, ?, ?, ?)",
-                202L, 102L, 2, Timestamp.valueOf(LocalDateTime.of(2025, 1, 1, 0, 0)));
-        jdbcTemplate.update(
-                "INSERT INTO contract (id, register_id, term_year, created_at) VALUES (?, ?, ?, ?)",
-                203L, 103L, 1, Timestamp.valueOf(LocalDateTime.of(2025, 6, 1, 0, 0)));
-
-        LocalDate d1 = LocalDate.of(2025, 10, 10);
-
-        jdbcTemplate.update(
-                "INSERT INTO usage_time (public_info_id, usage_date, call_amount, message_amount, data_amount) VALUES (?, ?, ?, ?, ?)",
-                "A000", Date.valueOf(d1), 100, 10, 5000);
-        jdbcTemplate.update(
-                "INSERT INTO usage_time (public_info_id, usage_date, call_amount, message_amount, data_amount) VALUES (?, ?, ?, ?, ?)",
-                "A001", Date.valueOf(d1), 200, 20, 10000);
-        jdbcTemplate.update(
-                "INSERT INTO usage_time (public_info_id, usage_date, call_amount, message_amount, data_amount) VALUES (?, ?, ?, ?, ?)",
-                "B001", Date.valueOf(d1), 300, 30, 15000);
-    }
 
     private JdbcPagingItemReader<BillingSourceRow> openReader(String lastId, String dateParam) throws Exception {
         PagingQueryProvider queryProvider = billingBatch.pagingQueryProvider(lastId, dateParam);

--- a/src/test/java/org/example/moono_backend/support/BillingFixture.java
+++ b/src/test/java/org/example/moono_backend/support/BillingFixture.java
@@ -5,11 +5,14 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 public class BillingFixture {
 
     private final JdbcTemplate jdbc;
+    private final List<String> publicInfoIds = new ArrayList<>();
 
     public BillingFixture(JdbcTemplate jdbc) {
         this.jdbc = jdbc;
@@ -43,6 +46,7 @@ public class BillingFixture {
 
     public void publicInfo(String id, long familyInfoId) {
         jdbc.update("INSERT INTO public_info (id, family_info_id) VALUES (?, ?)", id, familyInfoId);
+        publicInfoIds.add(id);
     }
 
     public void plan(long id, int baseFee, boolean premium) {
@@ -64,6 +68,13 @@ public class BillingFixture {
             INSERT INTO usage_time (public_info_id, usage_date, call_amount, message_amount, data_amount)
             VALUES (?, ?, ?, ?, ?)
         """, publicInfoId, Date.valueOf(usageDate), call, msg, data);
+    }
+
+    public String getFirstPublicInfoId() {
+        if (publicInfoIds.isEmpty()) {
+            throw new IllegalStateException("No public_info inserted");
+        }
+        return publicInfoIds.get(0);
     }
 }
 

--- a/src/test/java/org/example/moono_backend/support/BillingFixture.java
+++ b/src/test/java/org/example/moono_backend/support/BillingFixture.java
@@ -1,0 +1,69 @@
+package org.example.moono_backend.support;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class BillingFixture {
+
+    private final JdbcTemplate jdbc;
+
+    public BillingFixture(JdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    public void seedDefaultScenario(LocalDate usageDate) {
+        // public_info
+        publicInfo("A000", 10L);
+        publicInfo("A001", 11L);
+        publicInfo("B001", 12L);
+
+        // plan
+        plan(1L, 10000, true);
+        plan(2L, 7000, false);
+
+        // registration
+        registration(101L, "A000", 1L);
+        registration(102L, "A001", 1L);
+        registration(103L, "B001", 2L);
+
+        // contract
+        contract(201L, 101L, 2, LocalDateTime.of(2024, 1, 1, 0, 0));
+        contract(202L, 102L, 2, LocalDateTime.of(2025, 1, 1, 0, 0));
+        contract(203L, 103L, 1, LocalDateTime.of(2025, 6, 1, 0, 0));
+
+        // usage_time
+        usage("A000", usageDate, 100, 10, 5000);
+        usage("A001", usageDate, 200, 20, 10000);
+        usage("B001", usageDate, 300, 30, 15000);
+    }
+
+    public void publicInfo(String id, long familyInfoId) {
+        jdbc.update("INSERT INTO public_info (id, family_info_id) VALUES (?, ?)", id, familyInfoId);
+    }
+
+    public void plan(long id, int baseFee, boolean premium) {
+        jdbc.update("INSERT INTO plan (id, base_fee, premium_yn) VALUES (?, ?, ?)", id, baseFee, premium);
+    }
+
+    public void registration(long id, String publicInfoId, long planId) {
+        jdbc.update("INSERT INTO registration (id, public_info_id, plan_id) VALUES (?, ?, ?)",
+            id, publicInfoId, planId);
+    }
+
+    public void contract(long id, long registerId, int termYear, LocalDateTime createdAt) {
+        jdbc.update("INSERT INTO contract (id, register_id, term_year, created_at) VALUES (?, ?, ?, ?)",
+            id, registerId, termYear, Timestamp.valueOf(createdAt));
+    }
+
+    public void usage(String publicInfoId, LocalDate usageDate, int call, int msg, int data) {
+        jdbc.update("""
+            INSERT INTO usage_time (public_info_id, usage_date, call_amount, message_amount, data_amount)
+            VALUES (?, ?, ?, ?, ?)
+        """, publicInfoId, Date.valueOf(usageDate), call, msg, data);
+    }
+}
+

--- a/src/test/java/org/example/moono_backend/support/BillingTestDataSourceConfig.java
+++ b/src/test/java/org/example/moono_backend/support/BillingTestDataSourceConfig.java
@@ -1,0 +1,34 @@
+package org.example.moono_backend.support;
+
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.jdbc.datasource.init.DataSourceInitializer;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+
+@Configuration
+public class BillingTestDataSourceConfig {
+
+    @Bean
+    public DataSource dataSource() {
+        return new EmbeddedDatabaseBuilder()
+                .setType(EmbeddedDatabaseType.H2)
+                .setName("testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH")
+                .build();
+    }
+
+    @Bean
+    public DataSourceInitializer initializer(DataSource dataSource) {
+        DataSourceInitializer init = new DataSourceInitializer();
+        init.setDataSource(dataSource);
+
+        ResourceDatabasePopulator populator =
+                new ResourceDatabasePopulator(new ClassPathResource("schema.sql"));
+        init.setDatabasePopulator(populator);
+
+        return init;
+    }
+}


### PR DESCRIPTION
## 🍀 이슈 번호
#95 
- #이슈번호

## 작업 내용
- 요청에 따라 과금 내역을 JSON으로 저장하여 관리하게 변경
ex)
  ```json
  {
    "overages": [ //과금 내역
      { "type": "over_data", "amount": 131525 },
      { "type": "over_voice", "amount": 7392 },
      { "type": "over_sms", "amount": 4020 }
    ],
    "discounts": [ //할인 내역
      { "type": "select_contract", "amount": 16500 }
    ]
  }

## 체크리스트
- [ ] 코드 작성 완료
- [ ] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [ ] 코드 스타일/컨벤션 확인


## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용