### PR TITLE
[MOONO-58] Email Service 구현 & 공통 예외 처리 구조 

### DIFF
--- a/src/main/java/org/example/moono_backend/exception/BaseException.java
+++ b/src/main/java/org/example/moono_backend/exception/BaseException.java
@@ -1,0 +1,28 @@
+package org.example.moono_backend.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+
+    private final String billingId;
+    private final ErrorCode errorCode;
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.billingId = null;
+        this.errorCode = errorCode;
+    }
+
+    public BaseException(ErrorCode errorCode, String billingId) {
+        super(errorCode.getMessage());
+        this.billingId = billingId;
+        this.errorCode = errorCode;
+    }
+
+    public BaseException(ErrorCode errorCode, String billingId, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.billingId = billingId;
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/example/moono_backend/exception/EmailSendException.java
+++ b/src/main/java/org/example/moono_backend/exception/EmailSendException.java
@@ -1,0 +1,23 @@
+package org.example.moono_backend.exception;
+
+/**
+ * 이메일 발송 관련 예외
+ */
+public class EmailSendException extends BaseException {
+
+    public EmailSendException(ErrorCode errorCode, String billingId) {
+        super(errorCode, billingId);
+    }
+
+    public EmailSendException(ErrorCode errorCode, String billingId, Throwable cause) {
+        super(errorCode, billingId, cause);
+    }
+
+    public static EmailSendException sendFailed(String billingId, Throwable cause) {
+        return new EmailSendException(ErrorCode.EMAIL_SEND_FAILED, billingId, cause);
+    }
+
+    public static EmailSendException invalidRecipient(String billingId) {
+        return new EmailSendException(ErrorCode.EMAIL_INVALID_RECIPIENT, billingId);
+    }
+}

--- a/src/main/java/org/example/moono_backend/exception/ErrorCode.java
+++ b/src/main/java/org/example/moono_backend/exception/ErrorCode.java
@@ -1,0 +1,63 @@
+package org.example.moono_backend.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // ========== 멱등성 관련 ==========
+    ALREADY_COMPLETED("BILLING_001", "이미 처리 완료된 청구서입니다.", ErrorType.INFO),
+
+    // ========== 데이터 조회 관련 ==========
+    BILLING_NOT_FOUND("BILLING_002", "청구서를 찾을 수 없습니다.", ErrorType.WARNING),
+    USER_DND_POLICY_NOT_FOUND("BILLING_003", "사용자 금칙시간 정책을 찾을 수 없습니다.", ErrorType.INFO),
+
+    // ========== 금칙시간 관련 ==========
+    IN_QUIET_HOURS("BILLING_004", "현재 금칙시간입니다.", ErrorType.INFO),
+
+    // ========== 이메일 발송 관련 ==========
+    EMAIL_TEMPLATE_RENDER_FAILED("EMAIL_001", "이메일 템플릿 렌더링에 실패했습니다.", ErrorType.ERROR),
+    EMAIL_SEND_FAILED("EMAIL_002", "이메일 발송에 실패했습니다.", ErrorType.ERROR),
+    EMAIL_RETRY_FAILED("EMAIL_003", "이메일 재시도 발송에 실패했습니다.", ErrorType.ERROR),
+    EMAIL_INVALID_RECIPIENT("EMAIL_004", "유효하지 않은 수신자 정보입니다.", ErrorType.WARNING),
+
+    // ========== JSON 처리 관련 ==========
+    JSON_PARSING_FAILED("JSON_001", "JSON 파싱에 실패했습니다.", ErrorType.ERROR),
+    JSON_SERIALIZATION_FAILED("JSON_002", "JSON 직렬화에 실패했습니다.", ErrorType.ERROR),
+
+    // ========== 기타 ==========
+    UNKNOWN_ERROR("UNKNOWN_001", "알 수 없는 오류가 발생했습니다.", ErrorType.ERROR),
+    INTERNAL_SERVER_ERROR("INTERNAL_001", "내부 서버 오류가 발생했습니다.", ErrorType.ERROR);
+
+    private final String code;
+    private final String message;
+    private final ErrorType errorType;
+
+    public enum ErrorType {
+        INFO,      // 정보성 에러 (로깅만, 처리 계속)
+        WARNING,   // 경고 (로깅, 재시도 가능)
+        ERROR      // 에러 (로깅, 재시도 또는 Fallback)
+    }
+
+    public static ErrorCode findByCode(String code) {
+        for (ErrorCode errorCode : values()) {
+            if (errorCode.getCode().equals(code)) {
+                return errorCode;
+            }
+        }
+        return UNKNOWN_ERROR;
+    }
+
+    public boolean isRetryable() {
+        return errorType == ErrorType.WARNING || errorType == ErrorType.ERROR;
+    }
+
+    public boolean shouldSendToDLQ() {
+        return errorType == ErrorType.ERROR &&
+                (this == JSON_PARSING_FAILED ||
+                        this == JSON_SERIALIZATION_FAILED ||
+                        this == INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/org/example/moono_backend/exception/TemplateRenderException.java
+++ b/src/main/java/org/example/moono_backend/exception/TemplateRenderException.java
@@ -1,0 +1,19 @@
+package org.example.moono_backend.exception;
+
+/**
+ * 템플릿 렌더링 관련 예외
+ */
+public class TemplateRenderException extends BaseException {
+
+    public TemplateRenderException(ErrorCode errorCode, String billingId) {
+        super(errorCode, billingId);
+    }
+
+    public TemplateRenderException(ErrorCode errorCode, String billingId, Throwable cause) {
+        super(errorCode, billingId, cause);
+    }
+
+    public static TemplateRenderException renderFailed(String billingId, Throwable cause) {
+        return new TemplateRenderException(ErrorCode.EMAIL_TEMPLATE_RENDER_FAILED, billingId, cause);
+    }
+}

--- a/src/main/java/org/example/moono_backend/service/message/EmailService.java
+++ b/src/main/java/org/example/moono_backend/service/message/EmailService.java
@@ -1,0 +1,168 @@
+package org.example.moono_backend.service.message;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
+import com.github.jknack.handlebars.io.TemplateLoader;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.example.moono_backend.exception.EmailSendException;
+import org.example.moono_backend.exception.TemplateRenderException;
+import org.example.moono_backend.kafka.BillingDispatchDto;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+/**
+ * 이메일 발송 서비스
+ * 
+ * 공통 예외 처리 구조를 사용합니다.
+ * - TemplateRenderException: 템플릿 렌더링 실패
+ * - EmailSendException: 이메일 발송 실패
+ * 
+ * 재시도는 Kafka Consumer가 자동으로 처리하므로,
+ * 이 서비스는 1회 시도만 수행합니다.
+ * 실패 시 예외를 던져서 Consumer가 재시도하거나 DLT로 보냅니다.
+ */
+@Service
+@Slf4j
+public class EmailService {
+    
+    private Handlebars handlebars;
+    @SuppressWarnings("unused")
+    private final ObjectMapper objectMapper; // 향후 JSON 처리에 사용 예정
+
+    public EmailService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Handlebars 초기화 & 템플릿 로더 설정
+     */
+    @PostConstruct
+    public void init() {
+        // 템플릿 로더 설정: /templates/email -> .hbs 파일 로드
+        TemplateLoader loader = new ClassPathTemplateLoader("/templates/email", ".hbs");
+        this.handlebars = new Handlebars(loader);
+        log.info("Handlebars init complete");
+    }
+
+    /**
+     * 이메일 제목을 렌더링합니다.
+     * 
+     * @param dto BillingDispatchDto 객체
+     * @return 렌더링된 이메일 제목
+     * @throws TemplateRenderException 템플릿 렌더링 실패 시
+     */
+    public String renderEmailSubject(BillingDispatchDto dto) throws TemplateRenderException {
+        String billingId = dto.getHeader().getBillingId() != null
+                ? dto.getHeader().getBillingId().toString()
+                : null;
+
+        try {
+            log.debug("Rendering email subject for billingId: {}", billingId);
+            
+            Template template = handlebars.compile("billing-notification-subject");
+            String subject = template.apply(dto);
+            
+            log.debug("Email subject rendered successfully for billingId: {}", billingId);
+            return subject.trim();
+            
+        } catch (IOException e) {
+            log.error("Failed to render email subject for billingId: {}", billingId, e);
+            // 공통 예외 처리 구조 사용
+            throw TemplateRenderException.renderFailed(billingId, e);
+        }
+    }
+
+    /**
+     * 이메일 본문을 렌더링합니다.
+     * 
+     * @param dto BillingDispatchDto 객체
+     * @return 렌더링된 이메일 본문
+     * @throws TemplateRenderException 템플릿 렌더링 실패 시
+     */
+    public String renderEmailBody(BillingDispatchDto dto) throws TemplateRenderException {
+        String billingId = dto.getHeader().getBillingId() != null
+                ? dto.getHeader().getBillingId().toString()
+                : null;
+
+        try {
+            log.debug("Rendering email body for billingId: {}", billingId);
+            
+            Template template = handlebars.compile("billing-notification-body");
+            String body = template.apply(dto);
+            
+            log.debug("Email body rendered successfully for billingId: {}", billingId);
+            return body;
+            
+        } catch (IOException e) {
+            log.error("Failed to render email body for billingId: {}", billingId, e);
+            // 공통 예외 처리 구조 사용
+            throw TemplateRenderException.renderFailed(billingId, e);
+        }
+    }
+
+    /**
+     * 이메일 본문을 렌더링합니다 (기존 메서드명 유지)
+     * 
+     * @param dto BillingDispatchDto 객체
+     * @return 렌더링된 이메일 본문
+     * @throws TemplateRenderException 템플릿 렌더링 실패 시
+     */
+    public String renderEmail(BillingDispatchDto dto) throws TemplateRenderException {
+        return renderEmailBody(dto);
+    }
+
+    /**
+     * 실제 발송 로직
+     * 
+     * 재시도는 Kafka Consumer가 자동으로 처리하므로,
+     * 이 메서드는 1회 시도만 수행합니다.
+     * 실패 시 예외를 던져서 Consumer가 재시도하거나 DLT로 보냅니다.
+     * 
+     * @param dto BillingDispatchDto 객체
+     * @throws EmailSendException 이메일 발송 실패 시
+     */
+    public void sendBillingEmail(BillingDispatchDto dto) throws EmailSendException {
+        String billingId = dto.getHeader().getBillingId() != null
+                ? dto.getHeader().getBillingId().toString()
+                : null;
+
+        try {
+            log.info("Sending billing email to: {} (billingId: {})",
+                    dto.getReceiver().getEmail(), billingId);
+
+            // 수신자 유효성 검사
+            if (dto.getReceiver() == null || dto.getReceiver().getEmail() == null
+                    || dto.getReceiver().getEmail().isEmpty()) {
+                // 공통 예외 처리 구조 사용
+                throw EmailSendException.invalidRecipient(billingId);
+            }
+
+            // 템플릿 렌더링 (제목과 본문을 별도로 렌더링)
+            String subject = renderEmailSubject(dto);
+            String body = renderEmailBody(dto);
+
+            // TODO: 실제 이메일 발송 로직 구현
+            // Mock 구현: 로깅만 수행
+            log.info("Email sent successfully (MOCK) - To: {}, Subject: {}, Body length: {} bytes",
+                    dto.getReceiver().getEmail(), subject, body.length());
+            log.debug("Email body:\n{}", body);
+
+        } catch (TemplateRenderException e) {
+            // 템플릿 렌더링 실패는 EmailSendException으로 래핑
+            // 공통 예외 처리 구조 사용
+            throw EmailSendException.sendFailed(billingId, e);
+        } catch (EmailSendException e) {
+            // 이미 EmailSendException이면 그대로 전파
+            throw e;
+        } catch (Exception e) {
+            log.error("Failed to send email to: {} (billingId: {})",
+                    dto.getReceiver().getEmail(), billingId, e);
+            // 공통 예외 처리 구조 사용
+            throw EmailSendException.sendFailed(billingId, e);
+        }
+    }
+}

--- a/src/main/java/org/example/moono_backend/service/message/QuietHourService.java
+++ b/src/main/java/org/example/moono_backend/service/message/QuietHourService.java
@@ -1,0 +1,74 @@
+package org.example.moono_backend.service.message;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalTime;
+
+/**
+ * 금칙 시간 판단
+ *
+ * 사용자의 금칙 시간 설정에 따라 현재 시간이 금칙시간인지 판단한다.
+ */
+@Service
+@Slf4j
+public class QuietHourService {
+
+    /**
+     * 현재 시간이 금칙 시간인지판단한다.
+     *
+     * 날짜 경계 처리:
+     * 1. startDndTime < endDndTime (예: 10:00-12:00)
+     *      *    → 같은 날 내에서 시간 범위 체크
+     *      *    → now >= start && now < end
+     *
+     * 2. startDndTime > endDndTime (예: 22:00-02:00)
+     *      *    → 자정을 넘어가는 시간 범위 체크
+     *      *    → now >= start || now < end
+     *
+     * 전제 조건;
+     * - isDndActive = true일 경우에만 호출
+     * startDnd와 endDnd는 항상 다름
+     *
+     * @param startDndTime
+     * @param endDndTime
+     * @param now
+     * @return true: 금칙 시간임 , false:금칙시간이 아님
+     *
+     * @throws IllegalArgumentException startDndTime 또는 endDndTime이 null인 경우
+     **/
+    public boolean isDndTime(LocalTime startDndTime, LocalTime endDndTime, LocalTime now) {
+        //null 체크
+        if (startDndTime ==null || endDndTime == null|| now == null) {
+            log.warn("금지 시간 check 오류: null parameter. startDndTime={}, endDndTime={}, now={}",
+                     startDndTime, endDndTime, now);
+            throw new IllegalArgumentException("금지 시간은 null이 될 수 없습니다.");
+        }
+
+        //날짜 경계를 넘지 않는 경우 (10:00-12:00)
+        if(startDndTime.isBefore(endDndTime)){
+            boolean inQuietHours = !now.isBefore(startDndTime) && now.isBefore(endDndTime);
+
+            log.debug("Quiet hours check (same day): start={}, end={}, now={}, result={}",
+            startDndTime, endDndTime, now, inQuietHours);
+            return inQuietHours;
+        }
+        //날짜 경계를 넘는 경우 ( 22:00-02:00)
+        boolean inQuietHours = !now.isBefore(startDndTime) || now.isBefore(endDndTime);
+        log.debug("Quiet hours check (cross-day): start={}, end={}, now={}, result={}",
+                  startDndTime, endDndTime, now, inQuietHours);
+        return inQuietHours;
+    }
+    /**
+     * 현재 시간이 금칙시간인지 판단합니다 (현재 시간 자동 조회).
+     *
+     * @param startDndTime 금칙시간 시작 시간 (포함)
+     * @param endDndTime 금칙시간 종료 시간 (제외)
+     * @return true: 금칙시간임, false: 금칙시간 아님
+     */
+    public boolean isDndTime(LocalTime startDndTime, LocalTime endDndTime) {
+        return isDndTime(startDndTime, endDndTime, LocalTime.now());
+    }
+
+
+}

--- a/src/main/resources/templates/email/billing-notification-body.hbs
+++ b/src/main/resources/templates/email/billing-notification-body.hbs
@@ -1,0 +1,26 @@
+안녕하세요, {{receiver.name}}님. 항상 저희 서비스를 이용해 주셔서 감사합니다.
+
+1. 청구 요약:
+
+- 이번 달 납부하실 금액: {{billingSummary.totalAmount}} 원
+
+- 납부 기한: {{billingSummary.dueDate}}
+
+2. 항목별 상세 내역 (Breakdown):
+
+- 요금제 기본료: {{billingSummary.baseFee}} 원 (기본 요금제 정보)
+- 데이터/음성 사용량 초과분: {{billingSummary.usageFee}} 원 (사용량 데이터 기반)
+
+3. 부가 서비스 상세(VAS List)
+{{#each details.additionalServices}}
+    - {{this.name}} : {{this.price}} 원
+{{/each}}
+
+4. 할인 적용 상세 (Discount List)
+{{#each details.discounts}}
+    - {{this.name}} : -{{this.amount}} 원
+{{/each}}
+
+5. 최종 결제 금액
+
+- 총계: {{billingSummary.totalAmount}} 원 (VAT 포함)

--- a/src/main/resources/templates/email/billing-notification-subject.hbs
+++ b/src/main/resources/templates/email/billing-notification-subject.hbs
@@ -1,0 +1,1 @@
+[U+ 알림] {{receiver.name}}님, {{header.billingMonth}}분 통신 요금 청구 내역서입니다.

--- a/src/test/java/org/example/moono_backend/service/message/QuietHourServiceTest.java
+++ b/src/test/java/org/example/moono_backend/service/message/QuietHourServiceTest.java
@@ -1,0 +1,157 @@
+package org.example.moono_backend.service.message;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+@DisplayName("QuietHoursService 테스트")
+class QuietHourServiceTest {
+
+    private QuietHourService quietHourService;
+
+    @BeforeEach
+    void setUp() {
+        quietHourService = new QuietHourService();
+    }
+
+    //======= 같은 날 범위 테스트 =====d
+    @Test
+    @DisplayName("같은 날 범위 - 시작 시간 직전은 금칙시간 아님")
+    void sameDayRange_beforeStartTime_shouldReturnFalse() {
+        // given
+        LocalTime start = LocalTime.of(10, 0);
+        LocalTime end = LocalTime.of(12, 0);
+        LocalTime now = LocalTime.of(9, 59);
+
+        // when
+        boolean result = quietHourService.isDndTime(start, end, now);
+
+        // then
+        assertFalse(result, "시작 시간 직전은 금칙시간이 아님");
+    }
+    @Test
+    @DisplayName("같은 날 범위 - 시작 시간은 금칙시간 (보내면 안됨)")
+    void sameDayRange_atStartTime_shouldReturnTrue() {
+        // given
+        LocalTime start = LocalTime.of(10, 0);
+        LocalTime end = LocalTime.of(12, 0);
+        LocalTime now = LocalTime.of(10, 0);
+
+        // when
+        boolean result = quietHourService.isDndTime(start, end, now);
+
+        // then
+        assertTrue(result, "시작 시간은 금칙시간임 (보내면 안됨)");
+    }
+
+    @Test
+    @DisplayName("같은 날 범위 - 종료 시간은 금칙시간 아님 (보내도 됨)")
+    void sameDayRange_atEndTime_shouldReturnFalse() {
+        // given
+        LocalTime start = LocalTime.of(10, 0);
+        LocalTime end = LocalTime.of(12, 0);
+        LocalTime now = LocalTime.of(12, 0);
+
+        // when
+        boolean result = quietHourService.isDndTime(start, end, now);
+
+        // then
+        assertFalse(result, "종료 시간은 금칙시간이 아님 (보내도 됨)");
+    }
+
+    @Test
+    @DisplayName("같은 날 범위 - 종료 시간 이후는 금칙시간 아님")
+    void sameDayRange_afterEndTime_shouldReturnFalse() {
+        // given
+        LocalTime start = LocalTime.of(10, 0);
+        LocalTime end = LocalTime.of(12, 0);
+        LocalTime now = LocalTime.of(12, 1);
+
+        // when
+        boolean result = quietHourService.isDndTime(start, end, now);
+
+        // then
+        assertFalse(result, "종료 시간 이후는 금칙시간이 아님");
+    }
+
+    //======= 날짜 경계 넘는 범위 테스트 (startDndTime > endDndTime) =====
+    @Test
+    @DisplayName("날짜 경계 범위 - 시작 시간 직전은 금칙시간 아님")
+    void crossDayRange_beforeStartTime_shouldReturnFalse() {
+        // given
+        LocalTime start = LocalTime.of(22, 0);
+        LocalTime end = LocalTime.of(2, 0);
+        LocalTime now = LocalTime.of(21, 59);
+
+        // when
+        boolean result = quietHourService.isDndTime(start, end, now);
+
+        // then
+        assertFalse(result, "시작 시간 직전은 금칙시간이 아님");
+    }
+
+    @Test
+    @DisplayName("날짜 경계 범위 - 시작 시간은 금칙시간")
+    void crossDayRange_atStartTime_shouldReturnTrue() {
+        // given
+        LocalTime start = LocalTime.of(22, 0);
+        LocalTime end = LocalTime.of(2, 0);
+        LocalTime now = LocalTime.of(22, 0);
+
+        // when
+        boolean result = quietHourService.isDndTime(start, end, now);
+
+        // then
+        assertTrue(result, "시작 시간은 금칙시간임");
+    }
+
+    @Test
+    @DisplayName("날짜 경계 범위 - 종료 시간은 금칙시간 아님")
+    void crossDayRange_atEndTime_shouldReturnFalse() {
+        // given
+        LocalTime start = LocalTime.of(22, 0);
+        LocalTime end = LocalTime.of(2, 0);
+        LocalTime now = LocalTime.of(2, 0);
+
+        // when
+        boolean result = quietHourService.isDndTime(start, end, now);
+
+        // then
+        assertFalse(result, "종료 시간은 금칙시간이 아님");
+    }
+
+    @Test
+    @DisplayName("날짜 경계 범위 - 종료 시간 이후는 금칙시간 아님")
+    void crossDayRange_afterEndTime_shouldReturnFalse() {
+        // given
+        LocalTime start = LocalTime.of(22, 0);
+        LocalTime end = LocalTime.of(2, 0);
+        LocalTime now = LocalTime.of(2, 1);
+
+        // when
+        boolean result = quietHourService.isDndTime(start, end, now);
+
+        // then
+        assertFalse(result, "종료 시간 이후는 금칙시간이 아님");
+    }
+
+    @Test
+    @DisplayName("현재 시간 자동 조회 메서드 테스트")
+    void isInQuietHours_withoutNowParameter_shouldUseCurrentTime() {
+        // given
+        LocalTime start = LocalTime.of(10, 0);
+        LocalTime end = LocalTime.of(12, 0);
+
+        // 현재 시간이 11시라고 가정하면 금칙시간이어야 함
+        // 하지만 실제 현재 시간에 따라 결과가 달라지므로
+        // 이 테스트는 메서드가 예외 없이 실행되는지만 확인
+
+        // when & then
+        assertDoesNotThrow(() -> {
+            quietHourService.isDndTime(start, end);
+        }, "현재 시간 자동 조회 메서드는 예외를 발생시키지 않아야 함");
+    }
+}


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #94 

## 작업 내용
### 1. EmailService 구현 
- Handlebars 엔진을 사용하여 이메일 제목(subject)과 본문(body)을 분리하여 렌더링합니다.
- /templates/email/*.hbs 경로의 템플릿을 로드하도록 설정했습니다.

### 2. 공통 예외 처리 구조 exception 패키지 만들었습니다. 
- BaseException: 모든 비즈니스 예외 최상위 클래스로 biilingId를 포함해 장애 추적을 용이하게 합니다. 
- ErrorCode: 에러 코드, 에러 타입 정의 
   - isRetryabl(): 네트워크 장애등 일시적 오류 시 재시도 여부 
   - shouldSendToDLQ() : DLT 이동 여부판단 

### 3. 카프카 컨슈머 연동 
- 서비스레이어에서 1회 시도 후 적절한 예외를 던지고 실제 재시도는 Kafka Consumer의 DefaulrErrorHandler가 담당하도록 합니다. 

## 팀원들 리뷰  체크 사항 
- 예외 발생 시 로그에 billingId가 누락되지 않도록 구성했는데, 추가로 로그에 담아야 할 정보가 있을까요?
- 그리고 ErrorCode의 errortype 분류 리뷰해주시면 감사하겠습니다! 


## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용