### PR TITLE
[MOONO-64] kafka 전송 확인용 batch 로그 추가

### DIFF
--- a/src/main/java/org/example/moono_backend/batch/StepMetricsListener.java
+++ b/src/main/java/org/example/moono_backend/batch/StepMetricsListener.java
@@ -2,9 +2,12 @@ package org.example.moono_backend.batch;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.batch.core.ChunkListener;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
 
 /*
 
@@ -14,10 +17,11 @@ import org.springframework.batch.core.StepExecutionListener;
  * */
 @Slf4j
 @RequiredArgsConstructor
-public class StepMetricsListener implements StepExecutionListener {
+public class StepMetricsListener implements StepExecutionListener, ChunkListener {
 
     private final BatchMetrics batchMetrics;
     private long stepStartMillis;
+    private int chunkCount = 0; // 실시간 청크 카운팅용
 
     @Override
     public void beforeStep(StepExecution stepExecution) {
@@ -27,6 +31,32 @@ public class StepMetricsListener implements StepExecutionListener {
                 stepExecution.getStepName(),
                 stepExecution.getJobExecutionId(),
                 stepExecution.getId());
+    }
+
+    @Override
+    public void beforeChunk(ChunkContext context) {
+        // 특별한 로직이 없더라도 인터페이스 구현을 위해 비워둔 채로 둡니다.
+    }
+
+    @Override
+    public void afterChunk(ChunkContext context) {
+        chunkCount++;
+        long currentElapsed = System.currentTimeMillis() - stepStartMillis;
+
+        // 현재까지 읽은/쓴 양을 context에서 가져올 수 있습니다.
+        var stepExecution = context.getStepContext().getStepExecution();
+
+        log.info(">> [PROGRESS] {}번째 청크 완료 (읽기: {}건, 카프카전송: {}건, 누적 {}ms)",
+                chunkCount,
+                stepExecution.getReadCount(), // DB에서 읽어온 총 건수
+                stepExecution.getWriteCount(), // Processor를 통과해 Writer(카프카)로 전송 성공한 건수
+                currentElapsed);
+    }
+
+    @Override
+    public void afterChunkError(ChunkContext context) {
+        // 에러 발생 시 로그 추가 (선택 사항)
+        log.warn("!! [PROGRESS] {}번째 청크에서 에러 발생", chunkCount + 1);
     }
 
     @Override

--- a/src/main/java/org/example/moono_backend/batch/sending/SendingJobConfig.java
+++ b/src/main/java/org/example/moono_backend/batch/sending/SendingJobConfig.java
@@ -6,6 +6,7 @@ import org.example.moono_backend.domain.Billing;
 import org.example.moono_backend.kafka.BillingDispatchMessageDto;
 import org.example.moono_backend.repository.MemberCredentialRepository;
 import org.example.moono_backend.repository.UserDndPolicyRepository;
+import org.springframework.batch.core.ChunkListener;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -69,7 +70,8 @@ public class SendingJobConfig {
                 .reader(new SendingItemReader(entityManagerFactory))
                 .processor(sendingItemProcessor)
                 .writer(sendingItemWriter)
-                .listener(stepMetricsListener) // sendingStep 을 실행할때 자동으로 step 전 후 에 호출
+                .listener((StepExecutionListener) stepMetricsListener) // sendingStep 을 실행할때 자동으로 step 전 후 에 호출
+                .listener((ChunkListener) stepMetricsListener)
                 .build();
     }
 


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #104 

## 작업 내용
<!-- 작업한 부분을 설명해주세요. -->

- [x] 작업 1 배치 성능 및 카프카 전송 확인용 Listener 수정 및 추가
- [x]  StepMetricsListener 및 BatchMetrics 구현으로 청크 단위 처리 시간(Read/Map/Write) 실시간 로그 출력
- [x] 작업 2 연관관계 없는 UUID 구조에서 발생하는 반복 조회 병목(약 4.2분/청크) 확인
- [x] In-절을 활용한 Preload(애플리케이션 캐싱) 방식으로 진화하여 네트워크 I/O 최소화 예정

## 체크리스트
- [ x] 성능 측정용 리스너 수정 및 WriteCount 로그 확인 완료
- [ x] 카프카 토픽(sending-batch-topic) 정상 진입 확인 / 일단 스케줄러로 호출 안하고 controller 로 호출


## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용