### PR TITLE
[MOONO-65] [Feat] 카프카 DLT Consumer 서비스 구현

### DIFF
--- a/src/main/java/org/example/moono_backend/domain/EmailFailLog.java
+++ b/src/main/java/org/example/moono_backend/domain/EmailFailLog.java
@@ -1,15 +1,12 @@
 package org.example.moono_backend.domain;
 
-import org.example.moono_backend.domain.member.MemberCredential;
-
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EmailFailLog {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -20,5 +17,17 @@ public class EmailFailLog {
     @Enumerated(EnumType.STRING)
     private SmsSendStatus smsStatus;
 
+    @Column(length = 1024)
     private String payload; // 카프카 토픽에 담겼던 JSON 데이터 통째로 저장
+
+    @Enumerated(EnumType.STRING)
+    private ParseStatus parseStatus; // JSON 파싱 성공 여부
+
+    @Builder
+    public EmailFailLog(String publicInfoId, String payload, ParseStatus parseStatus) {
+        this.publicInfoId = publicInfoId;
+        this.smsStatus = SmsSendStatus.PENDING;
+        this.payload = payload;
+        this.parseStatus = parseStatus;
+    }
 }

--- a/src/main/java/org/example/moono_backend/domain/ParseStatus.java
+++ b/src/main/java/org/example/moono_backend/domain/ParseStatus.java
@@ -1,0 +1,6 @@
+package org.example.moono_backend.domain;
+
+public enum ParseStatus {
+    SUCCESS,
+    FAIL
+}

--- a/src/main/java/org/example/moono_backend/domain/SmsSendStatus.java
+++ b/src/main/java/org/example/moono_backend/domain/SmsSendStatus.java
@@ -3,5 +3,4 @@ package org.example.moono_backend.domain;
 public enum SmsSendStatus {
     SUCCESS, // sms 발송 완료 - Client 요청 응답시 suscess 처리
     PENDING, // sms 발송 대기 (email 실패 후 DB 저장된 상태)
-    FAIL // sms 발송 실패 -- 필요없을지도
 }

--- a/src/main/java/org/example/moono_backend/kafka/dlt/EmailSendDltConsumer.java
+++ b/src/main/java/org/example/moono_backend/kafka/dlt/EmailSendDltConsumer.java
@@ -1,0 +1,53 @@
+package org.example.moono_backend.kafka.dlt;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.moono_backend.domain.EmailFailLog;
+import org.example.moono_backend.domain.ParseStatus;
+import org.example.moono_backend.kafka.BillingDispatchMessageDto;
+import org.example.moono_backend.repository.EmailFailLogRepository;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailSendDltConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final EmailFailLogRepository emailFailLogRepository;
+
+    @Transactional
+    @KafkaListener(topics = "queuing.billing.email.send.dlt", groupId = "cg-billing-email-send-dlt")
+    public void consume(String message, Acknowledgment ack) {
+
+        BillingDispatchMessageDto dto;
+        try {
+            dto = objectMapper.readValue(message, BillingDispatchMessageDto.class);
+        } catch (JsonProcessingException e) {
+            log.error("DLT JSON 파싱 실패. message={}", message);
+            EmailFailLog emailFailLog = EmailFailLog.builder()
+                    .publicInfoId(null)
+                    .payload(message)
+                    .parseStatus(ParseStatus.FAIL)
+                    .build();
+            emailFailLogRepository.save(emailFailLog);
+            ack.acknowledge();
+            return;
+        }
+
+        String publicInfoId = dto.getHeader().getPublicInfoId();
+        EmailFailLog emailFailLog = EmailFailLog.builder()
+                .publicInfoId(publicInfoId)
+                .payload(message)
+                .parseStatus(ParseStatus.SUCCESS)
+                .build();
+
+        emailFailLogRepository.save(emailFailLog);
+        ack.acknowledge();
+    }
+}


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #108 
- 
## 작업 내용
- [x] EmailFailLog 수정
- [x] SmsSendStatus 수정
- [x] ParseStatus (Enum) 추가
- [x] EmailSendDltConsumer 구현

## 체크리스트
- [x] 코드 작성 완료
- [x] 테스트 완료

## 참고 사항
SmsSendStatus (ENUM) 의 FAIL 삭제
EmailFailLog 클래스에 ParseStatus (ENUM) JSON 파싱 여부 필드 추가