### PR TITLE
[MOONO-77] Kafka Consumer 설정 및 트랜잭션 관리 개선 

### DIFF
--- a/src/main/java/org/example/moono_backend/config/KafkaConfig.java
+++ b/src/main/java/org/example/moono_backend/config/KafkaConfig.java
@@ -1,5 +1,0 @@
-package org.example.moono_backend.config;
-
-public class KafkaConfig {
-
-}

--- a/src/main/java/org/example/moono_backend/kafka/config/KafkaConfig.java
+++ b/src/main/java/org/example/moono_backend/kafka/config/KafkaConfig.java
@@ -1,0 +1,125 @@
+package org.example.moono_backend.kafka.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.apache.kafka.clients.admin.NewTopic;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Kafka 토픽 자동 생성 설정
+ * 
+ * 역할:
+ * 1. KafkaAdmin Bean 생성 (토픽 관리용)
+ * 2. 필요한 토픽들을 자동으로 생성
+ * 
+ * 동작:
+ * - 애플리케이션 시작 시 토픽이 없으면 자동 생성
+ * - 토픽이 이미 있으면 기존 설정 유지 (파티션 개수 변경 안 됨)
+ * 
+ * 주의:
+ * - 파티션 개수는 토픽 생성 후 변경 불가 (증가만 가능)
+ * - 운영 환경에서는 이미 생성된 토픽이 있을 수 있으므로 주의
+ * - 토픽이 이미 존재하면 기존 설정을 유지하고 에러 없이 진행
+ * 
+ * 테스트 방법:
+ * 1. 애플리케이션 시작 시 로그 확인: "[KafkaConfig] 토픽 생성 설정..." 메시지 확인
+ * 2. Kafka UI (http://localhost:8989)에서 Topics 메뉴 확인
+ * 3. Kafka CLI: kafka-topics.sh --list --bootstrap-server localhost:29092
+ */
+@Slf4j
+@Configuration
+public class KafkaConfig {
+
+    private static final String BILLING_EMAIL_SEND_TOPIC = "queuing.billing.email.send";
+    private static final String BILLING_EMAIL_SEND_DLT_TOPIC = "queuing.billing.email.send.dlt";
+    private static final int PARTITION_COUNT = 3;  // 파티션 개수
+    private static final short REPLICATION_FACTOR = 1;  // 복제본 개수 (개발 환경)
+
+    /**
+     * KafkaAdmin Bean 생성
+     * 
+     * 역할: Kafka Admin API를 사용하여 토픽을 관리
+     * 
+     * @param kafkaProperties application.yml의 Kafka 설정
+     * @return KafkaAdmin 인스턴스
+     * 
+     * 동작:
+     * - application.yml의 bootstrap-servers 설정을 사용
+     * - Spring Boot가 자동으로 KafkaProperties를 주입
+     */
+    @Bean
+    public KafkaAdmin kafkaAdmin(KafkaProperties kafkaProperties) {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, 
+                   kafkaProperties.getBootstrapServers());
+        
+        KafkaAdmin kafkaAdmin = new KafkaAdmin(configs);
+        log.info("[KafkaConfig] KafkaAdmin 생성 완료. bootstrap-servers: {}", 
+                kafkaProperties.getBootstrapServers());
+        
+        return kafkaAdmin;
+    }
+
+    /**
+     * 청구서 이메일 발송 토픽 생성
+     * 
+     * 토픽명: queuing.billing.email.send
+     * 파티션: 3개 (병렬 처리 가능)
+     * 복제본: 1개 (개발 환경, 운영 환경에서는 3개 권장)
+     * 
+     * 동작:
+     * - 토픽이 없으면 자동 생성
+     * - 토픽이 이미 있으면 기존 설정 유지 (에러 없음)
+     * 
+     * @return NewTopic 인스턴스
+     */
+    @Bean
+    public NewTopic billingEmailSendTopic() {
+        NewTopic topic = TopicBuilder
+                .name(BILLING_EMAIL_SEND_TOPIC)
+                .partitions(PARTITION_COUNT)              // 파티션 개수
+                .replicas(REPLICATION_FACTOR)             // 복제본 개수 (개발 환경)
+                .build();
+        
+        log.info("[KafkaConfig] 토픽 생성 설정: {}, 파티션: {}, 복제본: {}", 
+                BILLING_EMAIL_SEND_TOPIC, PARTITION_COUNT, REPLICATION_FACTOR);
+        return topic;
+    }
+
+    /**
+     * DLT (Dead Letter Topic) 생성
+     * 
+     * 토픽명: queuing.billing.email.send.dlt
+     * 파티션: 3개 (원본 토픽과 동일)
+     * 복제본: 1개 (개발 환경)
+     * 
+     * 역할:
+     * - 재시도 실패한 메시지를 저장하는 토픽
+     * - EmailSendDltConsumer가 이 토픽에서 메시지를 수신하여 EmailFailLog에 저장
+     * 
+     * 동작:
+     * - 토픽이 없으면 자동 생성
+     * - 토픽이 이미 있으면 기존 설정 유지 (에러 없음)
+     * 
+     * @return NewTopic 인스턴스
+     */
+    @Bean
+    public NewTopic billingEmailSendDltTopic() {
+        NewTopic topic = TopicBuilder
+                .name(BILLING_EMAIL_SEND_DLT_TOPIC)
+                .partitions(PARTITION_COUNT)              // 파티션 개수
+                .replicas(REPLICATION_FACTOR)             // 복제본 개수 (개발 환경)
+                .build();
+        
+        log.info("[KafkaConfig] DLT 토픽 생성 설정: {}, 파티션: {}, 복제본: {}", 
+                BILLING_EMAIL_SEND_DLT_TOPIC, PARTITION_COUNT, REPLICATION_FACTOR);
+        return topic;
+    }
+}

--- a/src/main/java/org/example/moono_backend/kafka/config/KafkaErrorHandlerConfig.java
+++ b/src/main/java/org/example/moono_backend/kafka/config/KafkaErrorHandlerConfig.java
@@ -1,0 +1,197 @@
+package org.example.moono_backend.kafka.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.TopicPartition;
+import org.example.moono_backend.kafka.producer.BillingProducerMessageDto;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.ExponentialBackOff;
+
+/**
+ * Kafka 에러 처리 설정 클래스
+ *
+ * 역할:
+ * 1. 재시도 정책 설정 (Exponential Backoff)
+ * 2. Dead Letter Topic (DLT) 자동 전송 설정
+ * 3. 예외 타입별 처리 전략 정의
+ *
+ * DLT로 전송되는 케이스:
+ *
+ * EmailSendException (이메일 발송 실패 - 1% 확률)
+ *    - 발생 시점: BillingDispatchService.process() 실행 중
+ *    - 원인: 이메일 API 오류, 네트워크 문제 등 (일시적 오류 가능)
+ *    - 재시도: 가능 (Exponential Backoff로 재시도)
+ *    - DLT 처리: 재시도 후에도 실패 시 → EmailSendDltConsumer에서 ParseStatus.SUCCESS로 저장
+ *
+ * DLT로 전송하지 않는 케이스:
+ *
+ * DeserializationException (역직렬화 실패)
+ *    - 발생 시점: Consumer에서 JSON → BillingProducerMessageDto 변환 실패
+ *    - 원인: Producer에서 잘못된 데이터 전송, 네트워크 전송 중 데이터 손상 등
+ *    - 처리: 로깅만 하고 메시지 스킵 (DLT로 전송하지 않음)
+ *    - 이유: 역직렬화 실패는 데이터 자체의 문제이므로 DLT에 저장해도 의미 없음
+ *           Producer에서 데이터 검증을 강화하여 예방해야 함
+ *
+ * 처리 흐름:
+ * 1. Consumer에서 예외 발생
+ * 2. DefaultErrorHandler가 예외 타입에 따라 처리:
+ *    - DeserializationException: 로깅 후 메시지 스킵 (DLT로 전송 안 함)
+ *    - EmailSendException: Exponential Backoff로 재시도 후 DLT로 전송
+ * 3. DLT Consumer(EmailSendDltConsumer)가 EmailFailLog에 저장
+
+ */
+@Slf4j
+@Configuration
+public class KafkaErrorHandlerConfig {
+
+    private static final long INITIAL_INTERVAL_MS = 1000L; // 첫 재시도 간격: 1초
+    private static final double MULTIPLIER = 2.0; // 재시도 간격 배수: 2배씩 증가
+    private static final long MAX_INTERVAL_MS = 10000L; // 최대 재시도 간격: 10초
+    private static final long MAX_ELAPSED_TIME_MS = 30000L; // 최대 총 재시도 시간: 30초
+
+    // DLT 토픽명 접미사
+    private static final String DLT_TOPIC_SUFFIX = ".dlt";
+
+    /**
+     * DeadLetterPublishingRecoverer 생성
+     *
+     * 역할: 최대 재시도 횟수 초과 시 실패한 메시지를 DLT 토픽으로 자동 전송
+     *
+     * 주의: DeserializationException은 DLT로 전송하지 않음
+     *       (별도 처리 로직에서 스킵 처리)
+     *
+     * @param kafkaTemplate DLT 토픽으로 메시지를 전송하기 위한 KafkaTemplate
+     * @return DeadLetterPublishingRecoverer 인스턴스
+     *
+     * 동작 방식:
+     * 1. Consumer에서 EmailSendException 발생
+     * 2. Exponential Backoff로 재시도
+     * 3. 최대 재시도 횟수 초과 시 이 Recoverer가 호출됨
+     * 4. 원본 메시지를 DLT 토픽으로 전송
+     * 5. DLT Consumer(EmailSendDltConsumer)가 EmailFailLog에 저장
+     *    - ParseStatus.SUCCESS로 저장 (JSON은 정상)
+     */
+    @Bean
+    public DeadLetterPublishingRecoverer deadLetterPublishingRecoverer(
+            KafkaTemplate<String, BillingProducerMessageDto> kafkaTemplate) {
+
+        // DLT 토픽명 생성 전략: 원본 토픽명 + ".dlt"
+        // 예: "queuing.billing.email.send" -> "queuing.billing.email.send.dlt"
+        return new DeadLetterPublishingRecoverer(
+                kafkaTemplate,
+                (record, ex) -> {
+                    String originalTopic = record.topic();
+                    String dltTopic = originalTopic + DLT_TOPIC_SUFFIX;
+
+                    log.error("[ErrorHandler] 메시지를 DLT로 전송. " +
+                                      "원본 토픽: {}, DLT 토픽: {}, 예외 타입: {}, 파티션: {}, 오프셋: {}",
+                              originalTopic, dltTopic, ex.getClass().getSimpleName(),
+                              record.partition(), record.offset());
+
+                    return new TopicPartition(dltTopic, record.partition());
+                }
+        );
+    }
+
+    /**
+     * Exponential Backoff 전략 설정
+     *
+     * 역할: 재시도 간격을 점진적으로 증가시켜 시스템 부하를 줄임
+     *
+     * @return BackOff 인스턴스
+     *
+     * 재시도 간격 예시:
+     * - 1차 재시도: 1초 후
+     * - 2차 재시도: 2초 후 (1초 * 2)
+     * - 3차 재시도: 4초 후 (2초 * 2)
+     * - 4차 재시도: 8초 후 (4초 * 2)
+     * - 최대 간격: 10초로 제한
+     * - 최대 총 시간: 30초
+     *
+     * 왜 Exponential Backoff를 사용하는가?
+     * - 일시적 오류는 빠르게 해결될 수 있으므로 초기에는 짧은 간격
+     * - 지속적 오류는 시스템 부하를 줄이기 위해 간격을 점진적으로 증가
+     * - 최대 간격 제한으로 무한 대기를 방지
+     */
+    @Bean
+    public BackOff exponentialBackOff() {
+        ExponentialBackOff backOff = new ExponentialBackOff();
+        backOff.setInitialInterval(INITIAL_INTERVAL_MS);
+        backOff.setMultiplier(MULTIPLIER);
+        backOff.setMaxInterval(MAX_INTERVAL_MS);
+        backOff.setMaxElapsedTime(MAX_ELAPSED_TIME_MS);
+
+        log.info("[ErrorHandler] Exponential Backoff 설정 완료. " +
+                         "초기 간격: {}ms, 배수: {}, 최대 간격: {}ms, 최대 총 시간: {}ms",
+                 INITIAL_INTERVAL_MS, MULTIPLIER, MAX_INTERVAL_MS, MAX_ELAPSED_TIME_MS);
+
+        return backOff;
+    }
+
+    /**
+     * DefaultErrorHandler 생성
+     *
+     * 역할: Consumer에서 발생한 예외를 처리하고 재시도 정책을 적용
+     *
+     * @param deadLetterPublishingRecoverer 최대 재시도 초과 시 DLT로 전송하는 Recoverer
+     * @param exponentialBackOff 재시도 간격 전략
+     * @return CommonErrorHandler 인스턴스
+     *
+     * 처리 전략:
+     * 1. DeserializationException (JSON 파싱 실패): 로깅 후 메시지 스킵 (DLT로 전송 안 함)
+     *    - 이유: 역직렬화 실패는 데이터 자체의 문제이므로 DLT에 저장해도 의미 없음
+     *    - Producer에서 데이터 검증을 강화하여 예방해야 함
+     *    - 로깅만 하고 메시지를 스킵하여 다음 메시지 처리 계속
+     *
+     * 2. EmailSendException (이메일 발송 실패): Exponential Backoff로 재시도 후 DLT로 전송
+     *    - 이유: 일시적 네트워크 오류 등으로 발생할 수 있으므로 재시도 의미 있음
+     *    - 재시도 후에도 실패하면 DLT로 전송
+     *    - DLT 처리: EmailSendDltConsumer에서 ParseStatus.SUCCESS로 저장 (JSON은 정상)
+     *
+     * 3. 기타 예외: 재시도 후 DLT로 전송
+     *
+     * 왜 CommonErrorHandler를 반환하는가?
+     * - DefaultErrorHandler는 CommonErrorHandler의 구현체
+     * - 인터페이스로 반환하여 향후 다른 구현체로 교체 가능 (확장성)
+     */
+    @Bean
+    public CommonErrorHandler kafkaErrorHandler(
+            DeadLetterPublishingRecoverer deadLetterPublishingRecoverer,
+            BackOff exponentialBackOff) {
+
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(
+                deadLetterPublishingRecoverer,
+                exponentialBackOff
+        );
+
+        // DeserializationException은 재시도하지 않고, DLT로도 보내지 않음
+        // 로깅만 하고 메시지를 스킵하여 다음 메시지 처리 계속
+        errorHandler.addNotRetryableExceptions(DeserializationException.class);
+
+        // DeserializationException 발생 시 커스텀 처리
+        errorHandler.setRetryListeners((record, ex, deliveryAttempt) -> {
+            if (ex instanceof DeserializationException) {
+                log.error("[ErrorHandler] 역직렬화 실패 - 메시지 스킵. " +
+                                  "토픽: {}, 파티션: {}, 오프셋: {}, 예외: {}",
+                          record.topic(), record.partition(), record.offset(),
+                          ex.getMessage());
+                // DLT로 보내지 않고 메시지 스킵 (offset만 커밋)
+            }
+        });
+
+        // 복구된 메시지(즉, DLT로 전송된 메시지)는 커밋하여 중복 처리 방지
+        errorHandler.setCommitRecovered(true);
+
+        log.info("[ErrorHandler] DefaultErrorHandler 설정 완료. " +
+                         "DeserializationException은 로깅 후 스킵 (DLT로 전송 안 함), " +
+                         "EmailSendException 등 기타 예외는 재시도 후 DLT로 전송");
+
+        return errorHandler;
+    }
+}

--- a/src/main/java/org/example/moono_backend/kafka/dlt/EmailSendDltConsumer.java
+++ b/src/main/java/org/example/moono_backend/kafka/dlt/EmailSendDltConsumer.java
@@ -24,12 +24,13 @@ public class EmailSendDltConsumer {
     @Transactional
     @KafkaListener(topics = "queuing.billing.email.send.dlt", groupId = "cg-billing-email-send-dlt")
     public void consume(String message, Acknowledgment ack) {
+        log.info("[DLT] DLT 메시지 수신 시작");
 
         BillingProducerMessageDto dto;
         try {
             dto = objectMapper.readValue(message, BillingProducerMessageDto.class);
         } catch (JsonProcessingException e) {
-            log.error("DLT JSON 파싱 실패. message={}", message);
+            log.error("[DLT] JSON 파싱 실패 - ParseStatus.FAIL로 저장. message={}", message, e);
             EmailFailLog emailFailLog = EmailFailLog.builder()
                     .publicInfoId(null)
                     .payload(message)
@@ -37,6 +38,7 @@ public class EmailSendDltConsumer {
                     .build();
             emailFailLogRepository.save(emailFailLog);
             ack.acknowledge();
+            log.info("[DLT] EmailFailLog 저장 완료 (ParseStatus.FAIL)");
             return;
         }
 
@@ -49,5 +51,6 @@ public class EmailSendDltConsumer {
 
         emailFailLogRepository.save(emailFailLog);
         ack.acknowledge();
+        log.info("[DLT] EmailFailLog 저장 완료 (ParseStatus.SUCCESS). publicInfoId: {}", publicInfoId);
     }
 }

--- a/src/main/java/org/example/moono_backend/service/message/BillingDispatchService.java
+++ b/src/main/java/org/example/moono_backend/service/message/BillingDispatchService.java
@@ -38,7 +38,7 @@ public class BillingDispatchService {
     @Transactional
     public void process(BillingProducerMessageDto messageDto) throws EmailSendException {
         Long billingId = messageDto.getHeader().getBillingId();
-        log.info("Processing billingId: {}", billingId);
+        log.info("[Dispatch] 청구서 발송 처리 시작. billingId: {}", billingId);
 
         try {
             // 1. 멱등성 확인 : 이미 completed이면 처리하지 않음 -> 중복 발송 방지
@@ -54,7 +54,7 @@ public class BillingDispatchService {
 
             // 4. 금칙 시간 확인 (강제 발송이 아닌 경우)
             if (!isForced && checkQuietHours(messageDto, billing)) {
-                log.info("금칙 시간 확인 중.. billingId: {}", billingId);
+                log.info("[Dispatch] 금칙 시간으로 인해 발송 보류. billingId: {}", billingId);
                 return;
             }
 
@@ -69,14 +69,14 @@ public class BillingDispatchService {
 
             // 8. 발송 완료 상태 업데이트
             updateBillingStatus(billing, SendStatus.COMPLETED);
-            log.info("Billing email sent successfully. billingId: {}", billingId);
+            log.info("[Dispatch] 청구서 발송 처리 완료. billingId: {}", billingId);
 
         } catch (EmailSendException e) {
             // 이메일 발송 실패는 그대로 전파하여 Consumer가 재시도하도록 함
-            log.error("Email send failed for billingId: {}", billingId, e);
+            log.error("[Dispatch] 이메일 발송 실패. billingId: {}", billingId, e);
             throw e;
         } catch (Exception e) {
-            log.error("Unexpected error processing billingId: {}", billingId, e);
+            log.error("[Dispatch] 청구서 발송 처리 중 예상치 못한 오류. billingId: {}", billingId, e);
             throw EmailSendException.sendFailed(billingId != null ? billingId.toString() : null, e);
         }
     }
@@ -93,14 +93,14 @@ public class BillingDispatchService {
         Optional<Billing> billingOpt = billingRepository.findById(billingId);
 
         if (billingOpt.isEmpty()) {
-            log.warn("Billing not found for billingId: {}", billingId);
+            log.warn("[Dispatch] 청구서를 찾을 수 없음. billingId: {}", billingId);
             return false;
         }
         Billing billing = billingOpt.get();
         boolean isCompleted = billing.getSendStatus() == SendStatus.COMPLETED;
 
         if (isCompleted) {
-            log.info("Billing already processed for billingId: {}, status: {}", billingId, billing.getSendStatus());
+            log.info("[Dispatch] 이미 처리된 청구서. billingId: {}, status: {}", billingId, billing.getSendStatus());
         }
         return isCompleted;
     }
@@ -131,7 +131,7 @@ public class BillingDispatchService {
             String dndEnd = messageDto.getReceiver().getDndEnd();
 
             if (dndStart == null || dndEnd == null || dndStart.isEmpty() || dndEnd.isEmpty()) {
-                log.debug("DND time not set for billingId: {}", billing.getId());
+                log.debug("[Dispatch] 금칙 시간 미설정. billingId: {}", billing.getId());
                 return false;
             }
             LocalTime startDndTime = LocalTime.parse(dndStart);
@@ -141,15 +141,15 @@ public class BillingDispatchService {
             boolean inQuietHours = quietHourService.isDndTime(startDndTime, endDndTime, now);
             if (inQuietHours) {
                 updateBillingStatus(billing, SendStatus.IN_QUIET_HOUR);
-                log.info("Updated billing status to IN_QUIET_HOUR. billingId: {}, " +
-                        "quietHours: {} - {}",
+                log.info("[Dispatch] 청구서 상태를 IN_QUIET_HOUR로 업데이트. billingId: {}, " +
+                        "금칙 시간: {} - {}",
                         billing.getId(), startDndTime, endDndTime);
                 return true;
             }
             return false;
 
         } catch (Exception e) {
-            log.error("Failed to check DND time for billingId: {}", billing.getId(), e);
+            log.error("[Dispatch] 금칙 시간 확인 실패. billingId: {}", billing.getId(), e);
             return false;
         }
     }
@@ -164,13 +164,13 @@ public class BillingDispatchService {
             java.lang.reflect.Method setter = Billing.class.getMethod("setSendStatus", SendStatus.class);
             setter.invoke(billing, sendStatus);
             billingRepository.save(billing);
-            log.debug("Billing status updated. billingId: {}, status: {}", billing.getId(), sendStatus);
+            log.debug("[Dispatch] 청구서 상태 업데이트 완료. billingId: {}, status: {}", billing.getId(), sendStatus);
         } catch (NoSuchMethodException e) {
-            log.error("Billing entity does not have setSendStatus method. billingId: {}",
+            log.error("[Dispatch] Billing 엔티티에 setSendStatus 메서드가 없음. billingId: {}",
                     billing.getId(), e);
             throw new RuntimeException("Billing entity needs setter for sendStatus", e);
         } catch (Exception e) {
-            log.error("Failed to update billing status using reflection. billingId: {}",
+            log.error("[Dispatch] Reflection을 사용한 청구서 상태 업데이트 실패. billingId: {}",
                     billing.getId(), e);
             throw new RuntimeException("Failed to update billing status", e);
         }
@@ -181,16 +181,16 @@ public class BillingDispatchService {
      */
     private RawDetailsDto parseRawDetails(String rawDetails, Long billingId) {
         if (rawDetails == null || rawDetails.isEmpty()) {
-            log.warn("rawDetails is null or empty for billingId: {}", billingId);
+            log.warn("[Dispatch] rawDetails가 null이거나 비어있음. billingId: {}", billingId);
             return new RawDetailsDto(); // 빈 객체 반환
         }
 
         try {
             RawDetailsDto parsed = objectMapper.readValue(rawDetails, RawDetailsDto.class);
-            log.debug("Successfully parsed rawDetails for billingId: {}", billingId);
+            log.debug("[Dispatch] rawDetails JSON 파싱 성공. billingId: {}", billingId);
             return parsed;
         } catch (JsonProcessingException e) {
-            log.error("Failed to parse rawDetails JSON for billingId: {}", billingId, e);
+            log.error("[Dispatch] rawDetails JSON 파싱 실패. billingId: {}", billingId, e);
             throw new BillingDispatchException(
                     org.example.moono_backend.exception.ErrorCode.JSON_PARSING_FAILED,
                     billingId != null ? billingId.toString() : null,
@@ -222,10 +222,10 @@ public class BillingDispatchService {
                 header.getClass().getMethod("setIsForced", boolean.class)
                         .invoke(header, messageDto.getHeader().isForced());
             } catch (Exception ex) {
-                log.warn("Failed to set isForced field", ex);
+                log.warn("[Dispatch] isForced 필드 설정 실패", ex);
             }
         } catch (Exception e) {
-            log.warn("Failed to set isForced field", e);
+            log.warn("[Dispatch] isForced 필드 설정 실패", e);
         }
         dto.setHeader(header);
 

--- a/src/main/java/org/example/moono_backend/service/message/BillingDispatchService.java
+++ b/src/main/java/org/example/moono_backend/service/message/BillingDispatchService.java
@@ -13,6 +13,7 @@ import org.example.moono_backend.kafka.consumer.BillingConsumerMessageDto;
 import org.example.moono_backend.kafka.producer.BillingProducerMessageDto;
 import org.example.moono_backend.repository.BillingRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalTime;
@@ -34,42 +35,23 @@ public class BillingDispatchService {
      *
      * 실패 시 예외 던져 Consumer가 재시도하거나 DLT로 보내기
      * EmailFailLog 저장은 DLT Consumer에서 처리
+     * 
+     * 트랜잭션 관리:
+     * - DB 업데이트는 트랜잭션 내부에서 처리
+     * - 이메일 발송은 트랜잭션 외부에서 처리 (외부 API 호출)
      */
-    @Transactional
     public void process(BillingProducerMessageDto messageDto) throws EmailSendException {
         Long billingId = messageDto.getHeader().getBillingId();
         log.info("[Dispatch] 청구서 발송 처리 시작. billingId: {}", billingId);
 
         try {
-            // 1. 멱등성 확인 : 이미 completed이면 처리하지 않음 -> 중복 발송 방지
-            if (checkIdempotency(billingId)) {
-                return;
+            // 트랜잭션 내부: DB 조회 및 상태 업데이트
+            ProcessResult result = processInternal(messageDto);
+            
+            // 트랜잭션 외부: 이메일 발송 (외부 API 호출)
+            if (result.shouldSendEmail()) {
+                sendEmailAfterTransaction(result.getDispatchDto(), billingId);
             }
-
-            // 2. Billing 조회
-            Billing billing = getBillingOrThrow(billingId);
-
-            // 3. 강제 발송 확인
-            boolean isForced = messageDto.getHeader().isForced();
-
-            // 4. 금칙 시간 확인 (강제 발송이 아닌 경우)
-            if (!isForced && checkQuietHours(messageDto, billing)) {
-                log.info("[Dispatch] 금칙 시간으로 인해 발송 보류. billingId: {}", billingId);
-                return;
-            }
-
-            // 5. rawDetails 파싱 및 변환 (json 문자열을 RawDetailsDto로 파싱)
-            RawDetailsDto rawDetails = parseRawDetails(messageDto.getRawDetails(), billingId);
-
-            // 6. BillingProducerMessageDto를 BillingConsumerMessageDto로 변환
-            BillingConsumerMessageDto dispatchDto = convertToBillingDispatchDto(messageDto, rawDetails);
-
-            // 7. 이메일 발송 시도
-            emailService.sendBillingEmail(dispatchDto);
-
-            // 8. 발송 완료 상태 업데이트
-            updateBillingStatus(billing, SendStatus.COMPLETED);
-            log.info("[Dispatch] 청구서 발송 처리 완료. billingId: {}", billingId);
 
         } catch (EmailSendException e) {
             // 이메일 발송 실패는 그대로 전파하여 Consumer가 재시도하도록 함
@@ -78,6 +60,98 @@ public class BillingDispatchService {
         } catch (Exception e) {
             log.error("[Dispatch] 청구서 발송 처리 중 예상치 못한 오류. billingId: {}", billingId, e);
             throw EmailSendException.sendFailed(billingId != null ? billingId.toString() : null, e);
+        }
+    }
+
+    /**
+     * 트랜잭션 내부에서 수행되는 DB 작업
+     * 
+     * - 멱등성 확인
+     * - Billing 조회
+     * - 금칙 시간 확인 및 상태 업데이트
+     * - DTO 변환 준비
+     * 
+     * @param messageDto 메시지 DTO
+     * @return 처리 결과 (이메일 발송 여부 및 DTO 포함)
+     */
+    @Transactional
+    private ProcessResult processInternal(BillingProducerMessageDto messageDto) {
+        Long billingId = messageDto.getHeader().getBillingId();
+
+        // 1. 멱등성 확인 : 이미 completed이면 처리하지 않음 -> 중복 발송 방지
+        if (checkIdempotency(billingId)) {
+            return ProcessResult.skip();
+        }
+
+        // 2. Billing 조회
+        Billing billing = getBillingOrThrow(billingId);
+
+        // 3. 강제 발송 확인
+        boolean isForced = messageDto.getHeader().isForced();
+
+        // 4. 금칙 시간 확인 (강제 발송이 아닌 경우)
+        if (!isForced && checkQuietHours(messageDto, billing)) {
+            log.info("[Dispatch] 금칙 시간으로 인해 발송 보류. billingId: {}", billingId);
+            return ProcessResult.skip();
+        }
+
+        // 5. rawDetails 파싱 및 변환 (json 문자열을 RawDetailsDto로 파싱)
+        RawDetailsDto rawDetails = parseRawDetails(messageDto.getRawDetails(), billingId);
+
+        // 6. BillingProducerMessageDto를 BillingConsumerMessageDto로 변환
+        BillingConsumerMessageDto dispatchDto = convertToBillingDispatchDto(messageDto, rawDetails);
+
+        // 7. 발송 완료 상태 업데이트 (트랜잭션 내부에서 커밋)
+        updateBillingStatus(billing, SendStatus.COMPLETED);
+        log.info("[Dispatch] 청구서 상태 업데이트 완료. billingId: {}", billingId);
+
+        return ProcessResult.send(dispatchDto);
+    }
+
+    /**
+     * 트랜잭션 외부에서 수행되는 이메일 발송
+     * 
+     * 외부 API 호출이므로 트랜잭션과 분리하여 처리합니다.
+     * DB 업데이트가 커밋된 후에 이메일을 발송합니다.
+     * 
+     * @param dispatchDto 이메일 발송용 DTO
+     * @param billingId 청구서 ID
+     * @throws EmailSendException 이메일 발송 실패 시
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    private void sendEmailAfterTransaction(BillingConsumerMessageDto dispatchDto, Long billingId) 
+            throws EmailSendException {
+        log.info("[Dispatch] 이메일 발송 시작 (트랜잭션 외부). billingId: {}", billingId);
+        emailService.sendBillingEmail(dispatchDto);
+        log.info("[Dispatch] 청구서 발송 처리 완료. billingId: {}", billingId);
+    }
+
+    /**
+     * 처리 결과를 담는 내부 클래스
+     */
+    private static class ProcessResult {
+        private final boolean shouldSendEmail;
+        private final BillingConsumerMessageDto dispatchDto;
+
+        private ProcessResult(boolean shouldSendEmail, BillingConsumerMessageDto dispatchDto) {
+            this.shouldSendEmail = shouldSendEmail;
+            this.dispatchDto = dispatchDto;
+        }
+
+        static ProcessResult skip() {
+            return new ProcessResult(false, null);
+        }
+
+        static ProcessResult send(BillingConsumerMessageDto dispatchDto) {
+            return new ProcessResult(true, dispatchDto);
+        }
+
+        boolean shouldSendEmail() {
+            return shouldSendEmail;
+        }
+
+        BillingConsumerMessageDto getDispatchDto() {
+            return dispatchDto;
         }
     }
 
@@ -120,11 +194,13 @@ public class BillingDispatchService {
      * 현재 시간이 사용자의 금칙 시간에 해당하는지 확인하고,
      * 금칙 시간이면 상태를 IN_QUIET_HOUR로 업데이트합니다.
      * 
+     * 주의: 같은 클래스 내 private 메서드이므로 @Transactional이 적용되지 않습니다.
+     * 상위 메서드(processInternal)의 트랜잭션을 사용합니다.
+     * 
      * @param messageDto 메시지 DTO
      * @param billing    청구서 엔티티
      * @return true: 금칙 시간임, false: 금칙 시간 아님
      */
-    @Transactional
     private boolean checkQuietHours(BillingProducerMessageDto messageDto, Billing billing) {
         try {
             String dndStart = messageDto.getReceiver().getDndStart();

--- a/src/main/java/org/example/moono_backend/service/message/EmailService.java
+++ b/src/main/java/org/example/moono_backend/service/message/EmailService.java
@@ -45,7 +45,7 @@ public class EmailService {
         // 템플릿 로더 설정: /templates/email -> .hbs 파일 로드
         TemplateLoader loader = new ClassPathTemplateLoader("/templates/email", ".hbs");
         this.handlebars = new Handlebars(loader);
-        log.info("Handlebars init complete");
+        log.info("[EmailService] Handlebars 초기화 완료");
     }
 
     /**
@@ -61,16 +61,16 @@ public class EmailService {
                 : null;
 
         try {
-            log.debug("Rendering email subject for billingId: {}", billingId);
+            log.debug("[EmailService] 이메일 제목 렌더링 시작. billingId: {}", billingId);
 
             Template template = handlebars.compile("billing-notification-subject");
             String subject = template.apply(dto);
 
-            log.debug("Email subject rendered successfully for billingId: {}", billingId);
+            log.debug("[EmailService] 이메일 제목 렌더링 완료. billingId: {}", billingId);
             return subject.trim();
 
         } catch (IOException e) {
-            log.error("Failed to render email subject for billingId: {}", billingId, e);
+            log.error("[EmailService] 이메일 제목 렌더링 실패. billingId: {}", billingId, e);
             // 공통 예외 처리 구조 사용
             throw TemplateRenderException.renderFailed(billingId, e);
         }
@@ -89,16 +89,16 @@ public class EmailService {
                 : null;
 
         try {
-            log.debug("Rendering email body for billingId: {}", billingId);
+            log.debug("[EmailService] 이메일 본문 렌더링 시작. billingId: {}", billingId);
 
             Template template = handlebars.compile("billing-notification-body");
             String body = template.apply(dto);
 
-            log.debug("Email body rendered successfully for billingId: {}", billingId);
+            log.debug("[EmailService] 이메일 본문 렌더링 완료. billingId: {}", billingId);
             return body;
 
         } catch (IOException e) {
-            log.error("Failed to render email body for billingId: {}", billingId, e);
+            log.error("[EmailService] 이메일 본문 렌더링 실패. billingId: {}", billingId, e);
             // 공통 예외 처리 구조 사용
             throw TemplateRenderException.renderFailed(billingId, e);
         }
@@ -131,7 +131,7 @@ public class EmailService {
                 : null;
 
         try {
-            log.info("Sending billing email to: {} (billingId: {})",
+            log.info("[EmailService] 이메일 발송 시작. 수신자: {}, billingId: {}",
                     dto.getReceiver().getEmail(), billingId);
 
             // 수신자 유효성 검사
@@ -147,9 +147,9 @@ public class EmailService {
 
             // TODO: 실제 이메일 발송 로직 구현
             // Mock 구현: 로깅만 수행
-            log.info("Email sent successfully (MOCK) - To: {}, Subject: {}, Body length: {} bytes",
-                    dto.getReceiver().getEmail(), subject, body.length());
-            log.debug("Email body:\n{}", body);
+            log.info("[EmailService] 이메일 발송 완료 (MOCK). 수신자: {}, 제목: {}, 본문 길이: {} bytes, billingId: {}",
+                    dto.getReceiver().getEmail(), subject, body.length(), billingId);
+            log.debug("[EmailService] 이메일 본문:\n{}", body);
 
         } catch (TemplateRenderException e) {
             // 템플릿 렌더링 실패는 EmailSendException으로 래핑
@@ -159,7 +159,7 @@ public class EmailService {
             // 이미 EmailSendException이면 그대로 전파
             throw e;
         } catch (Exception e) {
-            log.error("Failed to send email to: {} (billingId: {})",
+            log.error("[EmailService] 이메일 발송 실패. 수신자: {}, billingId: {}",
                     dto.getReceiver().getEmail(), billingId, e);
             // 공통 예외 처리 구조 사용
             throw EmailSendException.sendFailed(billingId, e);


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #134 

## 작업 내용
<!-- 작업한 부분을 설명해주세요. -->
### application.yml 파일 수정 
```
kafka:
  bootstrap-servers: localhost:9092
  
  producer:
    value-serializer: JsonSerializer        # 객체 → JSON
    retries: 3                              # Broker 전송 실패 시 재시도
    acks: all                               # 모든 리더 확인
  
  consumer:
    value-deserializer: JsonDeserializer    # JSON → 객체
    enable-auto-commit: false               # 수동 커밋
    auto-offset-reset: earliest             # 처음부터 읽기
  
  listener:
    ack-mode: manual_immediate              # 수동 커밋 모드
```
### 0. Kafka Config 설정 추가 
```
설정 항목 | 값 | 설명
-- | -- | --
파티션 개수 | 3 | docker-compose.yml 기본값
복제본 | 1 | 개발 환경
재시도 간격 | 1초 → 10초 | Exponential Backoff
최대 재시도 시간 | 30초 | 총 재시도 시간 제한
커밋 방식 | 수동 | enable-auto-commit: false

```
### 1. Kafka 에러 처리 설정 클래스 추가 (`KafkaErrorHandlerConfig`)
- Exponential Backoff 재시도 전략 
   - 초기 간격: 1초 => 최대 간격: 10초 (2배씩 증가) 
   - 최대 총 재시도 기간: 30초 
** 이메일 발송 에러처리의 설정은 추후의 수정 예정입니다. **

- Dead Letter Topic (DLT 자동 전송) 
   -  재시도 실패 시 자동으로 DLT 토픽으로 전환 
   - 원본 토픽명  + `.dlt` 형식으로 토픽명 지정 
  

- 예외 타입별 처리 전략 
  -  역직렬화: 로깅 후 메시지 스킵 ( 이부분은 추후의 개선 할 것임 -> producer도 예외 처리 필요함) 

### 2. 트랜잭션 관리 개선 (`BillingDispatchService` ) 
- DB 업데이트와 외부 API 호출 분리 
  - DB 작업: `proocessInternal()`에서 적용 
  - 이메일 발송: `sendEmailAfterTransaction()` 메서드에서 트랜잭션 외부 처리
- 금칙시간 상태 업데이트 트랜잭션 처리 
    - checkQuietHours()메서드의 transaction제거하고, 상위 메서드에 트랜잭션 추가 

### 3. DLT 로깅 개선
 - DLT Consumer에서 상세한 로깅 추가 
 
## 체크리스트
- [ ] 코드 작성 완료
- [ ] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [ ] 코드 스타일/컨벤션 확인


## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용