### PR TITLE
[MOONO-75] 컨슈머 리플렉션 제거 및 Billing JSONB 타입 매핑 추가

### DIFF
--- a/src/main/java/org/example/moono_backend/domain/Billing.java
+++ b/src/main/java/org/example/moono_backend/domain/Billing.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 import org.example.moono_backend.domain.member.MemberCredential;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import lombok.*;
 
@@ -37,7 +39,17 @@ public class Billing {
 
     private LocalDateTime paidDate;
 
+    // Java의 String 데이터를 DB에 저장할 때 전용 JSON 타입으로 다루라고 Hibernate에 명시
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "jsonb")
     private String billingDetails;
+
+    public void completeSend() {
+        this.sendStatus = SendStatus.COMPLETED;
+    }
+
+    public void markAsInQuietHour() {
+        this.sendStatus = SendStatus.IN_QUIET_HOUR;
+    }
 
 }

--- a/src/main/java/org/example/moono_backend/service/message/BillingDispatchService.java
+++ b/src/main/java/org/example/moono_backend/service/message/BillingDispatchService.java
@@ -48,7 +48,7 @@ public class BillingDispatchService {
         try {
             // 트랜잭션 내부: DB 조회 및 상태 업데이트
             ProcessResult result = processInternal(messageDto);
-            
+
             // 트랜잭션 외부: 이메일 발송 (외부 API 호출)
             if (result.shouldSendEmail()) {
                 sendEmailAfterTransaction(result.getDispatchDto(), billingId);
@@ -116,14 +116,14 @@ public class BillingDispatchService {
      * DB 업데이트가 커밋된 후에 이메일을 발송합니다.
      * 
      * @param dispatchDto 이메일 발송용 DTO
-     * @param billingId 청구서 ID
+     * @param billingId   청구서 ID
      * @throws EmailSendException 이메일 발송 실패 시
      */
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     protected void sendEmailAfterTransaction(BillingConsumerMessageDto dispatchDto, Long billingId)
             throws EmailSendException {
         log.info("[Dispatch] 이메일 발송 시작 (트랜잭션 외부). billingId: {}", billingId);
-        
+
         // Chaos Engineering: 1% 확률로 장애 주입
         int randomValue = ThreadLocalRandom.current().nextInt(100);
         if (randomValue == 0) {
@@ -132,7 +132,7 @@ public class BillingDispatchService {
                     billingId != null ? billingId.toString() : null,
                     new RuntimeException("Chaos Engineering: Intentional failure injection (1% probability)"));
         }
-        
+
         emailService.sendBillingEmail(dispatchDto);
         log.info("[Dispatch] 청구서 발송 처리 완료. billingId: {}", billingId);
     }
@@ -246,21 +246,42 @@ public class BillingDispatchService {
      * 
      * Billing 엔티티에 setter가 없으므로 reflection을 사용합니다.
      */
+
+    /**
+     * private void updateBillingStatus(Billing billing, SendStatus sendStatus) {
+     * try {
+     * java.lang.reflect.Method setter = Billing.class.getMethod("setSendStatus",
+     * SendStatus.class);
+     * setter.invoke(billing, sendStatus);
+     * billingRepository.save(billing);
+     * log.debug("Billing status updated. billingId: {}, status: {}",
+     * billing.getId(), sendStatus);
+     * } catch (NoSuchMethodException e) {
+     * log.error("Billing entity does not have setSendStatus method. billingId: {}",
+     * billing.getId(), e);
+     * throw new RuntimeException("Billing entity needs setter for sendStatus", e);
+     * } catch (Exception e) {
+     * log.error("Failed to update billing status using reflection. billingId: {}",
+     * billing.getId(), e);
+     * throw new RuntimeException("Failed to update billing status", e);
+     * }
+     * }
+     **/
+
+    // 리플랙션 제거하고 set 메서드 직접 호출
     private void updateBillingStatus(Billing billing, SendStatus sendStatus) {
         try {
-            java.lang.reflect.Method setter = Billing.class.getMethod("setSendStatus", SendStatus.class);
-            setter.invoke(billing, sendStatus);
+            if (sendStatus == SendStatus.COMPLETED) {
+                billing.completeSend();
+            } else if (sendStatus == SendStatus.IN_QUIET_HOUR) {
+                billing.markAsInQuietHour();
+            }
             billingRepository.save(billing);
-            log.debug("[Dispatch] 청구서 상태 업데이트 완료. billingId: {}, status: {}", billing.getId(), sendStatus);
-        } catch (NoSuchMethodException e) {
-            log.error("[Dispatch] Billing 엔티티에 setSendStatus 메서드가 없음. billingId: {}",
-                    billing.getId(), e);
-            throw new RuntimeException("Billing entity needs setter for sendStatus", e);
         } catch (Exception e) {
-            log.error("[Dispatch] Reflection을 사용한 청구서 상태 업데이트 실패. billingId: {}",
-                    billing.getId(), e);
-            throw new RuntimeException("Failed to update billing status", e);
+            log.error("상태 업데이트 실패: billingId={}", billing.getId(), e);
+            throw new RuntimeException("Billing status update failed", e);
         }
+
     }
 
     /**


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #

## 작업 내용
<!-- 작업한 부분을 설명해주세요. -->

1. 도메인 모델(Billing) 개선 및 리플렉션 제거

문제: BillingDispatchService에서 리플렉션을 통해 setSendStatus를 호출했으나, 엔티티에 해당 메서드가 없어 NoSuchMethodException이 발생함.

해결:

- 엔티티에 명시적인 비즈니스 메서드(completeSend(), markAsInQuietHour())를 추가하여 캡슐화를 강화했습니다.

- 서비스 레이어에서 불안정한 리플렉션 로직을 제거하고 위 메서드들을 직접 호출하도록 변경했습니다.

2. PostgreSQL JSONB 타입 매핑 최적화
문제: billing_details 컬럼이 DB상에서는 jsonb 타입이나, JPA가 이를 character varying으로 처리하여 타입 불일치 에러 발생.

해결: @JdbcTypeCode(SqlTypes.JSON) 어노테이션을 추가하여 Java의 String이 DB의 jsonb 타입과 올바르게 호환되도록 수정했습니다.

## 체크리스트
- [ ] 코드 작성 완료
- [ ] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [ ] 코드 스타일/컨벤션 확인


## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용