### PR TITLE
[MOONO-75] Fix: Billing 엔티티 복구, 리플렉션 제거 및 Kafka ack 추가

### DIFF
--- a/src/main/java/org/example/moono_backend/domain/Billing.java
+++ b/src/main/java/org/example/moono_backend/domain/Billing.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 import org.example.moono_backend.domain.member.MemberCredential;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import lombok.*;
 
@@ -38,7 +40,17 @@ public class Billing {
 
     private LocalDateTime paidDate;
 
+    // Java의 String 데이터를 DB에 저장할 때 전용 JSON 타입으로 다루라고 Hibernate에 명시
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "jsonb")
     private String billingDetails;
+
+    public void completeSend() {
+        this.sendStatus = SendStatus.COMPLETED;
+    }
+
+    public void markAsInQuietHour() {
+        this.sendStatus = SendStatus.IN_QUIET_HOUR;
+    }
 
 }

--- a/src/main/java/org/example/moono_backend/kafka/consumer/KafkaConsumerListener.java
+++ b/src/main/java/org/example/moono_backend/kafka/consumer/KafkaConsumerListener.java
@@ -37,9 +37,9 @@ import org.springframework.stereotype.Component;
 public class KafkaConsumerListener {
 
     // 컨벤션: queuing.{도메인}.{기능}.{액션} 형식
-    private static final String TOPIC_NAME = "sending-topic";
+    private static final String TOPIC_NAME = "queuing.billing.email.send";
     // 컨벤션: cg-{도메인}-{기능}-{액션} 형식 (cg = consumer group)
-    private static final String GROUP_ID = "group_id";
+    private static final String GROUP_ID = "cg-billing-email-send";
 
     private final BillingDispatchService billingDispatchService;
 

--- a/src/main/java/org/example/moono_backend/service/message/BillingDispatchService.java
+++ b/src/main/java/org/example/moono_backend/service/message/BillingDispatchService.java
@@ -48,7 +48,7 @@ public class BillingDispatchService {
         try {
             // 트랜잭션 내부: DB 조회 및 상태 업데이트
             ProcessResult result = processInternal(messageDto);
-            
+
             // 트랜잭션 외부: 이메일 발송 (외부 API 호출)
             if (result.shouldSendEmail()) {
                 sendEmailAfterTransaction(result.getDispatchDto(), billingId);
@@ -116,14 +116,14 @@ public class BillingDispatchService {
      * DB 업데이트가 커밋된 후에 이메일을 발송합니다.
      * 
      * @param dispatchDto 이메일 발송용 DTO
-     * @param billingId 청구서 ID
+     * @param billingId   청구서 ID
      * @throws EmailSendException 이메일 발송 실패 시
      */
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     protected void sendEmailAfterTransaction(BillingConsumerMessageDto dispatchDto, Long billingId)
             throws EmailSendException {
         log.info("[Dispatch] 이메일 발송 시작 (트랜잭션 외부). billingId: {}", billingId);
-        
+
         // Chaos Engineering: 1% 확률로 장애 주입
         int randomValue = ThreadLocalRandom.current().nextInt(100);
         if (randomValue == 0) {
@@ -132,7 +132,7 @@ public class BillingDispatchService {
                     billingId != null ? billingId.toString() : null,
                     new RuntimeException("Chaos Engineering: Intentional failure injection (1% probability)"));
         }
-        
+
         emailService.sendBillingEmail(dispatchDto);
         log.info("[Dispatch] 청구서 발송 처리 완료. billingId: {}", billingId);
     }
@@ -246,21 +246,42 @@ public class BillingDispatchService {
      * 
      * Billing 엔티티에 setter가 없으므로 reflection을 사용합니다.
      */
+
+    /**
+     * private void updateBillingStatus(Billing billing, SendStatus sendStatus) {
+     * try {
+     * java.lang.reflect.Method setter = Billing.class.getMethod("setSendStatus",
+     * SendStatus.class);
+     * setter.invoke(billing, sendStatus);
+     * billingRepository.save(billing);
+     * log.debug("Billing status updated. billingId: {}, status: {}",
+     * billing.getId(), sendStatus);
+     * } catch (NoSuchMethodException e) {
+     * log.error("Billing entity does not have setSendStatus method. billingId: {}",
+     * billing.getId(), e);
+     * throw new RuntimeException("Billing entity needs setter for sendStatus", e);
+     * } catch (Exception e) {
+     * log.error("Failed to update billing status using reflection. billingId: {}",
+     * billing.getId(), e);
+     * throw new RuntimeException("Failed to update billing status", e);
+     * }
+     * }
+     **/
+
+    // 리플랙션 제거하고 set 메서드 직접 호출
     private void updateBillingStatus(Billing billing, SendStatus sendStatus) {
         try {
-            java.lang.reflect.Method setter = Billing.class.getMethod("setSendStatus", SendStatus.class);
-            setter.invoke(billing, sendStatus);
+            if (sendStatus == SendStatus.COMPLETED) {
+                billing.completeSend();
+            } else if (sendStatus == SendStatus.IN_QUIET_HOUR) {
+                billing.markAsInQuietHour();
+            }
             billingRepository.save(billing);
-            log.debug("[Dispatch] 청구서 상태 업데이트 완료. billingId: {}, status: {}", billing.getId(), sendStatus);
-        } catch (NoSuchMethodException e) {
-            log.error("[Dispatch] Billing 엔티티에 setSendStatus 메서드가 없음. billingId: {}",
-                    billing.getId(), e);
-            throw new RuntimeException("Billing entity needs setter for sendStatus", e);
         } catch (Exception e) {
-            log.error("[Dispatch] Reflection을 사용한 청구서 상태 업데이트 실패. billingId: {}",
-                    billing.getId(), e);
-            throw new RuntimeException("Failed to update billing status", e);
+            log.error("상태 업데이트 실패: billingId={}", billing.getId(), e);
+            throw new RuntimeException("Billing status update failed", e);
         }
+
     }
 
     /**


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #149 

## 작업 내용
<!-- 작업한 부분을 설명해주세요. -->

[복구 및 통합]
- 이전 PR 머지 과정에서의 히스토리 충돌(Revert)로 인해 유실되었던 기능 복원
- Revert 커밋으로 인해 develop 브랜치에서 삭제되었던 위 기존 작업 내용들을 reset --hard 및 cherry-pick을 통해 복구


[기존 작업]
1. Billing 엔티티 내 JSONB 매핑(@JdbcTypeCode) 적용
2. 기존의 자동커밋으로 설정해두었으나 KafkaConsumerListener 코드에는 Acknowledgment ack 파라미터가 추가되어 있던 문제 해결
3. BillingDispatchService 내 불필요한 리플렉션 로직을 제거하고 메서드 직접 호출 (@Setter 사용 대신) 
4. 유저별 설정 발송일에 따른 배치 필터링 로직 구현


[진행 계획]
- 프로듀서 측 상태 변경 로직 완성
