### PR TITLE
[MOONO-95] Consumer 복호화 로직 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ dependencies {
     // Handlebars 템플릿 엔진 (이메일 템플릿 렌더링용)
     implementation 'com.github.jknack:handlebars:4.3.1'
 
+    // BouncyCastle for PGP decryption (PostgreSQL pgcrypto 호환)
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
+    implementation 'org.bouncycastle:bcpg-jdk18on:1.78.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/moono_backend/exception/ErrorCode.java
+++ b/src/main/java/org/example/moono_backend/exception/ErrorCode.java
@@ -25,6 +25,12 @@ public enum ErrorCode {
     EMAIL_SEND_FAILED("EMAIL_002", "이메일 발송에 실패했습니다.", ErrorType.ERROR),
     EMAIL_RETRY_FAILED("EMAIL_003", "이메일 재시도 발송에 실패했습니다.", ErrorType.ERROR),
     EMAIL_INVALID_RECIPIENT("EMAIL_004", "유효하지 않은 수신자 정보입니다.", ErrorType.WARNING),
+    EMAIL_DECRYPTION_FAILED("EMAIL_005", "수신자 정보 복호화에 실패했습니다.", ErrorType.ERROR),
+
+    // ========== SMS 발송 관련 ==========
+    SMS_SEND_FAILED("SMS_001", "SMS 발송에 실패했습니다.", ErrorType.ERROR),
+    SMS_INVALID_PHONE_NUMBER("SMS_002", "유효하지 않은 전화번호입니다.", ErrorType.WARNING),
+    SMS_DECRYPTION_FAILED("SMS_003", "전화번호 복호화에 실패했습니다.", ErrorType.ERROR),
 
     // ========== JSON 처리 관련 ==========
     JSON_PARSING_FAILED("JSON_001", "JSON 파싱에 실패했습니다.", ErrorType.ERROR),

--- a/src/main/java/org/example/moono_backend/kafka/consumer/KafkaConsumerListener.java
+++ b/src/main/java/org/example/moono_backend/kafka/consumer/KafkaConsumerListener.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.moono_backend.config.AppProfiles;
 import org.example.moono_backend.domain.EmailFailLog;
 import org.example.moono_backend.domain.ParseStatus;
+import org.example.moono_backend.exception.BaseException;
 import org.example.moono_backend.exception.EmailSendException;
 import org.example.moono_backend.kafka.producer.BillingProducerMessageDto;
 import org.example.moono_backend.repository.EmailFailLogRepository;
@@ -40,8 +41,9 @@ import java.util.concurrent.Executor;
  * 3. 성공/실패에 따라 로깅 및 예외 처리
  *
  * 에러 처리:
- * - 이메일 발송 실패: 재시도 후 DLT로 전송
- * - 기타 예외: 재시도 후 DLT로 전송
+ * - 이메일 발송 실패 (EmailSendException): DLT로 전송
+ * - 복호화 실패 (BaseException): DLT로 전송
+ * - 기타 예외: DLT로 전송
  *
  * @Profile("consumer"): consumer 프로파일이 활성화된 경우에만 동작
  * - 이유: 배치 작업과 Consumer를 분리하여 운영 환경에서 선택적으로 활성화
@@ -100,11 +102,19 @@ public class KafkaConsumerListener {
                 log.info("[Consumer] 비동기 처리 완료. ack 호출. billingId: {}", billingId);
                 ack.acknowledge();
             } catch (EmailSendException e) {
-                log.warn("[Consumer] 이메일 발송 실패. billingId: {}", billingId);
+                log.warn("[Consumer] 이메일 발송 실패. DLT 전송. billingId: {}", billingId);
+                kafkaTemplate.send(DLT_TOPIC, messageDto);
+                ack.acknowledge();
+            } catch (BaseException e) {
+                // 복호화 실패(EMAIL_DECRYPTION_FAILED, SMS_DECRYPTION_FAILED 등) 포함
+                log.error("[Consumer] 비즈니스 로직 오류. DLT 전송. errorCode: {}, billingId: {}", 
+                        e.getErrorCode().getCode(), billingId, e);
                 kafkaTemplate.send(DLT_TOPIC, messageDto);
                 ack.acknowledge();
             } catch (Exception e) {
-                log.error("[Consumer] 예상치 못한 오류. billingId: {}", billingId, e);
+                log.error("[Consumer] 예상치 못한 오류. DLT 전송. billingId: {}", billingId, e);
+                kafkaTemplate.send(DLT_TOPIC, messageDto);
+                ack.acknowledge();
             }
         }, emailExecutor);
     }

--- a/src/main/java/org/example/moono_backend/service/EmailFailLogService.java
+++ b/src/main/java/org/example/moono_backend/service/EmailFailLogService.java
@@ -1,5 +1,6 @@
 package org.example.moono_backend.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.moono_backend.domain.EmailFailLog;
@@ -7,12 +8,26 @@ import org.example.moono_backend.domain.ParseStatus;
 import org.example.moono_backend.domain.SmsSendStatus;
 import org.example.moono_backend.exception.BaseException;
 import org.example.moono_backend.exception.ErrorCode;
+import org.example.moono_backend.kafka.producer.BillingProducerMessageDto;
 import org.example.moono_backend.repository.EmailFailLogRepository;
+import org.example.moono_backend.utils.CryptoUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+/**
+ * EmailFailLog 서비스
+ * 
+ * 역할:
+ * - 이메일 발송 실패 로그 조회 및 관리
+ * - SMS 재발송 처리 (payload에서 전화번호 복호화)
+ * 
+ * 보안 정책:
+ * - payload는 암호화된 상태로 저장됨 (DLT에서 저장)
+ * - SMS 발송 시에만 전화번호를 복호화하여 사용
+ * - 로그에는 마스킹된 전화번호만 출력
+ */
 @Slf4j
 @Service
 @Transactional(readOnly = true)
@@ -20,6 +35,8 @@ import java.util.List;
 public class EmailFailLogService {
 
     private final EmailFailLogRepository emailFailLogRepository;
+    private final CryptoUtil cryptoUtil;
+    private final ObjectMapper objectMapper;
 
     public List<EmailFailLog> findSmsPendingTargets() {
         return emailFailLogRepository.findByParseStatusAndSmsStatus(ParseStatus.SUCCESS, SmsSendStatus.PENDING);
@@ -29,10 +46,86 @@ public class EmailFailLogService {
         return emailFailLogRepository.findById(id).orElseThrow(() -> new BaseException(ErrorCode.ENTITY_NOT_FOUND));
     }
 
+    /**
+     * SMS 발송 및 상태 업데이트
+     * 
+     * 처리 흐름:
+     * 1. EmailFailLog 조회 (payload는 암호화된 상태)
+     * 2. payload 파싱 (BillingProducerMessageDto)
+     * 3. 전화번호 복호화 (SMS 발송 직전)
+     * 4. SMS 발송 (Mock: 무조건 성공 처리)
+     * 5. 상태 업데이트 (PENDING → SUCCESS)
+     * 
+     * @param id EmailFailLog ID
+     * @throws BaseException payload 파싱 또는 복호화 실패 시
+     */
     @Transactional
     public void update(Long id) {
         EmailFailLog emailFailLog = findById(id);
-        log.info("[SMS-SEND][SUCCESS] emailFailLogId={}, payload={}", id, emailFailLog.getPayload());
-        emailFailLog.update(SmsSendStatus.SUCCESS);
+        
+        try {
+            log.info("[SMS-SEND] SMS 발송 시작. emailFailLogId={}", id);
+
+            // 1. payload 파싱 (암호화된 상태)
+            BillingProducerMessageDto messageDto = objectMapper.readValue(
+                emailFailLog.getPayload(), 
+                BillingProducerMessageDto.class
+            );
+            
+            // 2. 전화번호 복호화 (SMS 발송 직전)
+            String encryptedPhone = messageDto.getReceiver().getPhone();
+            String decryptedPhone = cryptoUtil.decrypt(encryptedPhone);
+            
+            // 3. SMS 발송 (Mock: 무조건 성공)
+            log.info("[SMS-SEND][SUCCESS] SMS 발송 완료 (MOCK). 수신자: {}, emailFailLogId={}", 
+                    maskPhone(decryptedPhone), id);
+            
+            // 4. 상태 업데이트
+            emailFailLog.update(SmsSendStatus.SUCCESS);
+            
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            log.error("[SMS-SEND][FAILED] payload JSON 파싱 실패. emailFailLogId={}", id, e);
+            throw new BaseException(ErrorCode.JSON_PARSING_FAILED);
+        } catch (RuntimeException e) {
+            // cryptoUtil.decrypt()가 던지는 RuntimeException
+            log.error("[SMS-SEND][FAILED] 전화번호 복호화 실패. emailFailLogId={}", id, e);
+            throw new BaseException(ErrorCode.SMS_DECRYPTION_FAILED);
+        } catch (Exception e) {
+            log.error("[SMS-SEND][FAILED] 예상치 못한 오류. emailFailLogId={}", id, e);
+            throw new BaseException(ErrorCode.SMS_SEND_FAILED);
+        }
+    }
+
+    /**
+     * 전화번호 마스킹 (로그 보안)
+     * 
+     * 예시:
+     * - 010-1234-5678 -> ***-****-5678
+     * - 01012345678 -> *******5678
+     * 
+     * @param phone 원본 전화번호
+     * @return 마스킹된 전화번호
+     */
+    private String maskPhone(String phone) {
+        if (phone == null || phone.isEmpty()) {
+            return "***";
+        }
+
+        // 하이픈 제거
+        String digitsOnly = phone.replaceAll("[^0-9]", "");
+        
+        if (digitsOnly.length() < 4) {
+            return "***";
+        }
+
+        // 뒤 4자리만 표시
+        String lastFour = digitsOnly.substring(digitsOnly.length() - 4);
+        
+        // 원본에 하이픈이 있으면 형식 유지
+        if (phone.contains("-")) {
+            return "***-****-" + lastFour;
+        } else {
+            return "*******" + lastFour;
+        }
     }
 }

--- a/src/main/java/org/example/moono_backend/service/EmailFailLogService.java
+++ b/src/main/java/org/example/moono_backend/service/EmailFailLogService.java
@@ -76,7 +76,7 @@ public class EmailFailLogService {
             String phone = messageDto.getReceiver().getPhone();
             String decryptedPhone = cryptoUtil.isEncrypted(phone) ? cryptoUtil.decrypt(phone) : phone;
             
-            log.debug("[SMS-SEND] 전화번호 처리 완료 (암호화: {}). emailFailLogId={}", 
+            log.info("[SMS-SEND] 전화번호 처리 완료 (암호화: {}). emailFailLogId={}", 
                     cryptoUtil.isEncrypted(phone), id);
             
             // 3. SMS 발송 (Mock: 무조건 성공)

--- a/src/main/java/org/example/moono_backend/service/EmailFailLogService.java
+++ b/src/main/java/org/example/moono_backend/service/EmailFailLogService.java
@@ -72,9 +72,12 @@ public class EmailFailLogService {
                 BillingProducerMessageDto.class
             );
             
-            // 2. 전화번호 복호화 (SMS 발송 직전)
-            String encryptedPhone = messageDto.getReceiver().getPhone();
-            String decryptedPhone = cryptoUtil.decrypt(encryptedPhone);
+            // 2. 전화번호 복호화 (암호화된 경우만)
+            String phone = messageDto.getReceiver().getPhone();
+            String decryptedPhone = cryptoUtil.isEncrypted(phone) ? cryptoUtil.decrypt(phone) : phone;
+            
+            log.debug("[SMS-SEND] 전화번호 처리 완료 (암호화: {}). emailFailLogId={}", 
+                    cryptoUtil.isEncrypted(phone), id);
             
             // 3. SMS 발송 (Mock: 무조건 성공)
             log.info("[SMS-SEND][SUCCESS] SMS 발송 완료 (MOCK). 수신자: {}, emailFailLogId={}", 

--- a/src/main/java/org/example/moono_backend/service/message/EmailService.java
+++ b/src/main/java/org/example/moono_backend/service/message/EmailService.java
@@ -232,7 +232,7 @@ public class EmailService {
             
             decrypted.setReceiver(receiver);
 
-            log.debug("[EmailService] Receiver 정보 처리 완료 (암호화: name={}, email={}, phone={}). billingId: {}", 
+            log.info("[EmailService] Receiver 정보 처리 완료 (암호화: name={}, email={}, phone={}). billingId: {}", 
                 cryptoUtil.isEncrypted(name), cryptoUtil.isEncrypted(email), cryptoUtil.isEncrypted(phone), billingId);
             return decrypted;
             

--- a/src/main/java/org/example/moono_backend/service/message/EmailService.java
+++ b/src/main/java/org/example/moono_backend/service/message/EmailService.java
@@ -7,7 +7,9 @@ import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
 import com.github.jknack.handlebars.io.TemplateLoader;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.example.moono_backend.exception.BaseException;
 import org.example.moono_backend.exception.EmailSendException;
+import org.example.moono_backend.exception.ErrorCode;
 import org.example.moono_backend.exception.TemplateRenderException;
 import org.example.moono_backend.kafka.consumer.BillingConsumerMessageDto;
 import org.example.moono_backend.utils.CryptoUtil;
@@ -182,6 +184,9 @@ public class EmailService {
         } catch (EmailSendException e) {
             // 이미 EmailSendException이면 그대로 전파
             throw e;
+        } catch (BaseException e) {
+            // BaseException (복호화 실패 등)은 그대로 전파
+            throw e;
         } catch (Exception e) {
             log.error("[EmailService] 이메일 발송 실패. billingId: {}", billingId, e);
             throw EmailSendException.sendFailed(billingId, e);
@@ -196,28 +201,37 @@ public class EmailService {
      * 
      * @param dto 암호화된 BillingConsumerMessageDto
      * @return 복호화된 BillingConsumerMessageDto
+     * @throws BaseException 복호화 실패 시 EMAIL_DECRYPTION_FAILED
      */
     private BillingConsumerMessageDto decryptReceiverInfo(BillingConsumerMessageDto dto) {
-        BillingConsumerMessageDto decrypted = new BillingConsumerMessageDto();
+        String billingId = extractBillingId(dto);
+        
+        try {
+            BillingConsumerMessageDto decrypted = new BillingConsumerMessageDto();
 
-        // Header 복사 (암호화되지 않음)
-        decrypted.setHeader(dto.getHeader());
+            // Header 복사 (암호화되지 않음)
+            decrypted.setHeader(dto.getHeader());
 
-        // BillingSummary 복사 (암호화되지 않음)
-        decrypted.setBillingSummary(dto.getBillingSummary());
+            // BillingSummary 복사 (암호화되지 않음)
+            decrypted.setBillingSummary(dto.getBillingSummary());
 
-        // Details 복사 (암호화되지 않음)
-        decrypted.setDetails(dto.getDetails());
+            // Details 복사 (암호화되지 않음)
+            decrypted.setDetails(dto.getDetails());
 
-        // Receiver 복호화
-        BillingConsumerMessageDto.Receiver receiver = new BillingConsumerMessageDto.Receiver();
-        receiver.setName(cryptoUtil.decrypt(dto.getReceiver().getName()));
-        receiver.setEmail(cryptoUtil.decrypt(dto.getReceiver().getEmail()));
-        receiver.setPhone(cryptoUtil.decrypt(dto.getReceiver().getPhone()));
-        decrypted.setReceiver(receiver);
+            // Receiver 복호화
+            BillingConsumerMessageDto.Receiver receiver = new BillingConsumerMessageDto.Receiver();
+            receiver.setName(cryptoUtil.decrypt(dto.getReceiver().getName()));
+            receiver.setEmail(cryptoUtil.decrypt(dto.getReceiver().getEmail()));
+            receiver.setPhone(cryptoUtil.decrypt(dto.getReceiver().getPhone()));
+            decrypted.setReceiver(receiver);
 
-        log.debug("[EmailService] Receiver 정보 복호화 완료. billingId: {}", extractBillingId(dto));
-        return decrypted;
+            log.debug("[EmailService] Receiver 정보 복호화 완료. billingId: {}", billingId);
+            return decrypted;
+            
+        } catch (Exception e) {
+            log.error("[EmailService] Receiver 정보 복호화 실패. billingId: {}", billingId, e);
+            throw new BaseException(ErrorCode.EMAIL_DECRYPTION_FAILED);
+        }
     }
 
     /**

--- a/src/main/java/org/example/moono_backend/service/message/EmailService.java
+++ b/src/main/java/org/example/moono_backend/service/message/EmailService.java
@@ -10,7 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.moono_backend.exception.EmailSendException;
 import org.example.moono_backend.exception.TemplateRenderException;
 import org.example.moono_backend.kafka.consumer.BillingConsumerMessageDto;
-import org.springframework.scheduling.annotation.Async;
+import org.example.moono_backend.utils.CryptoUtil;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -25,6 +25,11 @@ import java.io.IOException;
  * 재시도는 Kafka Consumer가 자동으로 처리하므로,
  * 이 서비스는 1회 시도만 수행합니다.
  * 실패 시 예외를 던져서 Consumer가 재시도하거나 DLT로 보냅니다.
+ * 
+ * 보안 정책:
+ * - 이메일 발송 직전에 암호화된 Receiver 정보(이름, 이메일, 전화번호)를 복호화
+ * - 원본 DTO는 변경하지 않고 새로운 복호화된 DTO 생성
+ * - 로그에는 마스킹된 이메일만 출력 (보안 유지)
  */
 @Service
 @Slf4j
@@ -33,9 +38,11 @@ public class EmailService {
     private Handlebars handlebars;
     @SuppressWarnings("unused")
     private final ObjectMapper objectMapper; // 향후 JSON 처리에 사용 예정
+    private final CryptoUtil cryptoUtil; // 복호화 유틸리티
 
-    public EmailService(ObjectMapper objectMapper) {
+    public EmailService(ObjectMapper objectMapper, CryptoUtil cryptoUtil) {
         this.objectMapper = objectMapper;
+        this.cryptoUtil = cryptoUtil;
     }
 
     /**
@@ -123,32 +130,38 @@ public class EmailService {
      * 이 메서드는 1회 시도만 수행합니다.
      * 실패 시 예외를 던져서 Consumer가 재시도하거나 DLT로 보냅니다.
      * 
-     * @param dto BillingDispatchDto 객체
+     * 복호화 정책:
+     * - 이메일 발송 직전에만 Receiver 정보(이름, 이메일, 전화번호)를 복호화
+     * - 원본 DTO는 변경하지 않음 (DLT 저장 시 암호화 상태 유지)
+     * 
+     * @param dto BillingDispatchDto 객체 (암호화된 상태)
      * @throws EmailSendException 이메일 발송 실패 시
      */
     public void sendBillingEmail(BillingConsumerMessageDto dto) throws EmailSendException {
-        String billingId = dto.getHeader().getBillingId() != null
-                ? dto.getHeader().getBillingId().toString()
-                : null;
+        String billingId = extractBillingId(dto);
 
         try {
-            log.info("[EmailService] 이메일 발송 시작. 수신자: {}, billingId: {}",
-                    dto.getReceiver().getEmail(), billingId);
+            log.info("[EmailService] 이메일 발송 시작. billingId: {}", billingId);
 
-            // 수신자 유효성 검사
-            if (dto.getReceiver() == null || dto.getReceiver().getEmail() == null
-                    || dto.getReceiver().getEmail().isEmpty()) {
-                // 공통 예외 처리 구조 사용
+            // 1. Receiver 정보 복호화 (이메일 발송 직전)
+            BillingConsumerMessageDto decryptedDto = decryptReceiverInfo(dto);
+
+            // 2. 수신자 유효성 검사
+            if (decryptedDto.getReceiver() == null || decryptedDto.getReceiver().getEmail() == null
+                    || decryptedDto.getReceiver().getEmail().isEmpty()) {
                 throw EmailSendException.invalidRecipient(billingId);
             }
 
-            // 템플릿 렌더링 (제목과 본문을 별도로 렌더링)
-            String subject = renderEmailSubject(dto);
-            String body = renderEmailBody(dto);
+            // 3. 템플릿 렌더링 (복호화된 데이터 사용)
+            String subject = renderEmailSubject(decryptedDto);
+            String body = renderEmailBody(decryptedDto);
+
+            // 4. 이메일 발송 API 호출
+            log.info("[EmailService] 이메일 발송 API 호출. 수신자: {}, billingId: {}",
+                    maskEmail(decryptedDto.getReceiver().getEmail()), billingId);
 
             // 요구사항: 이메일 발송 1초 delay
             // 실제 외부 이메일 API 호출 시 응답 시간을 시뮬레이션
-            log.debug("[EmailService] 이메일 발송 API 호출 중... (1초 소요 예상)");
             try {
                 Thread.sleep(1000); // 1초 대기
             } catch (InterruptedException e) {
@@ -160,21 +173,90 @@ public class EmailService {
             // TODO: 실제 이메일 발송 로직 구현
             // Mock 구현: 로깅만 수행
             log.info("[EmailService] 이메일 발송 완료 (MOCK). 수신자: {}, 제목: {}, 본문 길이: {} bytes, billingId: {}",
-                    dto.getReceiver().getEmail(), subject, body.length(), billingId);
+                    maskEmail(decryptedDto.getReceiver().getEmail()), subject, body.length(), billingId);
             log.debug("[EmailService] 이메일 본문:\n{}", body);
 
         } catch (TemplateRenderException e) {
             // 템플릿 렌더링 실패는 EmailSendException으로 래핑
-            // 공통 예외 처리 구조 사용
             throw EmailSendException.sendFailed(billingId, e);
         } catch (EmailSendException e) {
             // 이미 EmailSendException이면 그대로 전파
             throw e;
         } catch (Exception e) {
-            log.error("[EmailService] 이메일 발송 실패. 수신자: {}, billingId: {}",
-                    dto.getReceiver().getEmail(), billingId, e);
-            // 공통 예외 처리 구조 사용
+            log.error("[EmailService] 이메일 발송 실패. billingId: {}", billingId, e);
             throw EmailSendException.sendFailed(billingId, e);
         }
+    }
+
+    /**
+     * Receiver 정보 복호화
+     * 
+     * 원본 DTO는 변경하지 않고 새로운 복호화된 DTO를 생성합니다.
+     * 이렇게 하면 DLT 저장 시 원본(암호화된 상태)을 유지할 수 있습니다.
+     * 
+     * @param dto 암호화된 BillingConsumerMessageDto
+     * @return 복호화된 BillingConsumerMessageDto
+     */
+    private BillingConsumerMessageDto decryptReceiverInfo(BillingConsumerMessageDto dto) {
+        BillingConsumerMessageDto decrypted = new BillingConsumerMessageDto();
+
+        // Header 복사 (암호화되지 않음)
+        decrypted.setHeader(dto.getHeader());
+
+        // BillingSummary 복사 (암호화되지 않음)
+        decrypted.setBillingSummary(dto.getBillingSummary());
+
+        // Details 복사 (암호화되지 않음)
+        decrypted.setDetails(dto.getDetails());
+
+        // Receiver 복호화
+        BillingConsumerMessageDto.Receiver receiver = new BillingConsumerMessageDto.Receiver();
+        receiver.setName(cryptoUtil.decrypt(dto.getReceiver().getName()));
+        receiver.setEmail(cryptoUtil.decrypt(dto.getReceiver().getEmail()));
+        receiver.setPhone(cryptoUtil.decrypt(dto.getReceiver().getPhone()));
+        decrypted.setReceiver(receiver);
+
+        log.debug("[EmailService] Receiver 정보 복호화 완료. billingId: {}", extractBillingId(dto));
+        return decrypted;
+    }
+
+    /**
+     * 이메일 마스킹 (로그 보안)
+     * 
+     * 예시:
+     * - user@example.com -> us***@example.com
+     * - a@test.com -> a***@test.com
+     * 
+     * @param email 원본 이메일
+     * @return 마스킹된 이메일
+     */
+    private String maskEmail(String email) {
+        if (email == null || !email.contains("@")) {
+            return "***";
+        }
+
+        String[] parts = email.split("@");
+        String prefix = parts[0];
+        String domain = parts[1];
+
+        // 앞 2글자만 표시, 나머지는 ***
+        String maskedPrefix = prefix.length() > 2
+                ? prefix.substring(0, 2) + "***"
+                : prefix.charAt(0) + "***";
+
+        return maskedPrefix + "@" + domain;
+    }
+
+    /**
+     * BillingId 안전 추출
+     * 
+     * @param dto BillingConsumerMessageDto
+     * @return billingId 문자열 (null일 수 있음)
+     */
+    private String extractBillingId(BillingConsumerMessageDto dto) {
+        if (dto == null || dto.getHeader() == null || dto.getHeader().getBillingId() == null) {
+            return null;
+        }
+        return dto.getHeader().getBillingId().toString();
     }
 }

--- a/src/main/java/org/example/moono_backend/service/message/EmailService.java
+++ b/src/main/java/org/example/moono_backend/service/message/EmailService.java
@@ -218,14 +218,22 @@ public class EmailService {
             // Details 복사 (암호화되지 않음)
             decrypted.setDetails(dto.getDetails());
 
-            // Receiver 복호화
+            // Receiver 복호화 (암호화된 경우만)
             BillingConsumerMessageDto.Receiver receiver = new BillingConsumerMessageDto.Receiver();
-            receiver.setName(cryptoUtil.decrypt(dto.getReceiver().getName()));
-            receiver.setEmail(cryptoUtil.decrypt(dto.getReceiver().getEmail()));
-            receiver.setPhone(cryptoUtil.decrypt(dto.getReceiver().getPhone()));
+            
+            String name = dto.getReceiver().getName();
+            String email = dto.getReceiver().getEmail();
+            String phone = dto.getReceiver().getPhone();
+            
+            // 암호화 여부 체크 후 복호화
+            receiver.setName(cryptoUtil.isEncrypted(name) ? cryptoUtil.decrypt(name) : name);
+            receiver.setEmail(cryptoUtil.isEncrypted(email) ? cryptoUtil.decrypt(email) : email);
+            receiver.setPhone(cryptoUtil.isEncrypted(phone) ? cryptoUtil.decrypt(phone) : phone);
+            
             decrypted.setReceiver(receiver);
 
-            log.debug("[EmailService] Receiver 정보 복호화 완료. billingId: {}", billingId);
+            log.debug("[EmailService] Receiver 정보 처리 완료 (암호화: name={}, email={}, phone={}). billingId: {}", 
+                cryptoUtil.isEncrypted(name), cryptoUtil.isEncrypted(email), cryptoUtil.isEncrypted(phone), billingId);
             return decrypted;
             
         } catch (Exception e) {

--- a/src/main/java/org/example/moono_backend/utils/CryptoUtil.java
+++ b/src/main/java/org/example/moono_backend/utils/CryptoUtil.java
@@ -1,0 +1,265 @@
+package org.example.moono_backend.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openpgp.*;
+import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPDigestCalculatorProviderBuilder;
+import org.bouncycastle.openpgp.operator.jcajce.JcePBEDataDecryptorFactoryBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.Security;
+
+/**
+ * PostgreSQL pgcrypto의 pgp_sym_encrypt/decrypt 호환 복호화 유틸리티
+ * 
+ * 역할:
+ * - PostgreSQL에서 pgp_sym_encrypt로 암호화된 데이터를 Java에서 복호화
+ * - BouncyCastle 라이브러리를 사용하여 OpenPGP 표준 복호화 지원
+ * 
+ * 사용 시나리오:
+ * 1. DB에 암호화된 상태로 저장된 개인정보 (이름, 이메일, 전화번호)
+ * 2. Kafka를 통해 암호화된 상태로 전송된 데이터
+ * 3. Consumer 단계에서 실제 이메일/SMS 발송 시 복호화 필요
+ * 
+ * 보안 정책:
+ * - 이메일 발송 시: 복호화하여 실제 값으로 발송
+ * - SMS 발송 시: 복호화하여 실제 전화번호로 발송
+ * - 로그 저장 시: 암호화된 상태 유지 (복호화 하지 않음)
+ * 
+ * PostgreSQL 쿼리 예시:
+ * <pre>
+ * -- 암호화
+ * INSERT INTO member_credential (name, email, phone_number)
+ * VALUES (
+ *   pgp_sym_encrypt('홍길동', 'secret-key'),
+ *   pgp_sym_encrypt('user@example.com', 'secret-key'),
+ *   pgp_sym_encrypt('010-1234-5678', 'secret-key')
+ * );
+ * 
+ * -- 복호화 (PostgreSQL)
+ * SELECT 
+ *   pgp_sym_decrypt(name::bytea, 'secret-key') as name,
+ *   pgp_sym_decrypt(email::bytea, 'secret-key') as email
+ * FROM member_credential;
+ * </pre>
+ */
+@Slf4j
+@Component
+public class CryptoUtil {
+
+    @Value("${crypto.secret-key}")
+    private String secretKey;
+
+    @Value("${crypto.enabled:true}")
+    private boolean enabled;
+
+    static {
+        // BouncyCastle Provider 등록 (OpenPGP 지원)
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    /**
+     * PostgreSQL pgp_sym_decrypt 호환 복호화
+     * 
+     * @param encryptedData 암호화된 데이터 (PostgreSQL bytea에서 가져온 문자열)
+     * @return 복호화된 평문
+     * @throws RuntimeException 복호화 실패 시
+     */
+    public String decrypt(String encryptedData) {
+        // 복호화 비활성화 시 원본 반환 (테스트 환경)
+        if (!enabled) {
+            log.debug("[CryptoUtil] 복호화 비활성화 - 원본 반환");
+            return encryptedData;
+        }
+
+        // null 또는 빈 문자열은 그대로 반환
+        if (encryptedData == null || encryptedData.isEmpty()) {
+            return encryptedData;
+        }
+
+        try {
+            log.debug("[CryptoUtil] 복호화 시작. 데이터 길이: {}", encryptedData.length());
+
+            // PostgreSQL bytea 형식 파싱
+            byte[] encryptedBytes = parsePostgresByteA(encryptedData);
+            
+            // PGP 메시지 스트림 생성
+            InputStream inputStream = new ByteArrayInputStream(encryptedBytes);
+            InputStream decoderStream = PGPUtil.getDecoderStream(inputStream);
+            
+            // PGP 객체 팩토리 생성
+            PGPObjectFactory pgpFactory = new PGPObjectFactory(
+                decoderStream,
+                new BcKeyFingerprintCalculator()
+            );
+
+            // 암호화된 데이터 리스트 추출
+            Object obj = pgpFactory.nextObject();
+            PGPEncryptedDataList encryptedDataList;
+            
+            if (obj instanceof PGPEncryptedDataList) {
+                encryptedDataList = (PGPEncryptedDataList) obj;
+            } else {
+                // 첫 번째 객체가 마커인 경우 다음 객체 읽기
+                encryptedDataList = (PGPEncryptedDataList) pgpFactory.nextObject();
+            }
+
+            // PGP 대칭키 암호화 데이터 추출
+            PGPPBEEncryptedData pbeEncryptedData = (PGPPBEEncryptedData) encryptedDataList.get(0);
+            
+            // 복호화 팩토리 생성 및 데이터 스트림 열기
+            InputStream decryptedStream = pbeEncryptedData.getDataStream(
+                new JcePBEDataDecryptorFactoryBuilder(
+                    new JcaPGPDigestCalculatorProviderBuilder().build()
+                ).setProvider(BouncyCastleProvider.PROVIDER_NAME).build(secretKey.toCharArray())
+            );
+
+            // 복호화된 데이터에서 리터럴 데이터 추출
+            PGPObjectFactory plainFactory = new PGPObjectFactory(
+                decryptedStream,
+                new BcKeyFingerprintCalculator()
+            );
+
+            Object plainObj = plainFactory.nextObject();
+            
+            // 압축된 데이터인 경우 압축 해제
+            if (plainObj instanceof PGPCompressedData) {
+                PGPCompressedData compressedData = (PGPCompressedData) plainObj;
+                InputStream compressedStream = compressedData.getDataStream();
+                plainFactory = new PGPObjectFactory(
+                    compressedStream,
+                    new BcKeyFingerprintCalculator()
+                );
+                plainObj = plainFactory.nextObject();
+            }
+
+            // 리터럴 데이터 추출
+            if (plainObj instanceof PGPLiteralData) {
+                PGPLiteralData literalData = (PGPLiteralData) plainObj;
+                InputStream literalStream = literalData.getInputStream();
+                
+                byte[] decryptedBytes = literalStream.readAllBytes();
+                String decrypted = new String(decryptedBytes, StandardCharsets.UTF_8);
+                
+                log.debug("[CryptoUtil] 복호화 성공. 결과 길이: {}", decrypted.length());
+                return decrypted;
+            } else {
+                throw new IllegalStateException("예상치 못한 PGP 객체 타입: " + plainObj.getClass().getName());
+            }
+
+        } catch (Exception e) {
+            log.error("[CryptoUtil] 복호화 실패. 데이터 프리픽스: {}..., 오류: {}", 
+                    encryptedData.substring(0, Math.min(50, encryptedData.length())), 
+                    e.getMessage(), e);
+            throw new RuntimeException("복호화 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * PostgreSQL bytea 형식 파싱
+     * 
+     * PostgreSQL bytea는 여러 형식으로 표현될 수 있음:
+     * 1. Hex format: \x4142434445... (가장 흔한 형식)
+     * 2. Escape format: \001\002\003...
+     * 3. Raw bytes: 바이너리 데이터 그대로
+     * 
+     * @param byteaString PostgreSQL bytea 문자열
+     * @return 바이트 배열
+     */
+    private byte[] parsePostgresByteA(String byteaString) {
+        if (byteaString.startsWith("\\x")) {
+            // Hex format: \x4142434445...
+            String hexString = byteaString.substring(2);
+            return hexStringToByteArray(hexString);
+        } else if (byteaString.startsWith("\\")) {
+            // Escape format: 복잡하므로 PostgreSQL JDBC 드라이버의 PGbytea 클래스 사용 권장
+            // 현재는 간단히 UTF-8 바이트로 변환
+            return byteaString.getBytes(StandardCharsets.UTF_8);
+        } else {
+            // Raw bytes 또는 이미 디코딩된 데이터
+            return byteaString.getBytes(StandardCharsets.ISO_8859_1);
+        }
+    }
+
+    /**
+     * Hex 문자열을 바이트 배열로 변환
+     * 
+     * @param hex Hex 문자열 (예: "414243" -> byte[]{0x41, 0x42, 0x43})
+     * @return 바이트 배열
+     */
+    private byte[] hexStringToByteArray(String hex) {
+        int len = hex.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(hex.charAt(i), 16) << 4)
+                    + Character.digit(hex.charAt(i + 1), 16));
+        }
+        return data;
+    }
+
+    /**
+     * 데이터가 암호화되어 있는지 확인
+     * 
+     * @param data 확인할 데이터
+     * @return 암호화 여부
+     */
+    public boolean isEncrypted(String data) {
+        if (data == null || data.isEmpty()) {
+            return false;
+        }
+        
+        // PostgreSQL bytea hex format 확인
+        if (data.startsWith("\\x")) {
+            return true;
+        }
+        
+        // 일반적으로 암호화된 데이터는 길이가 길고 특수 문자가 많음
+        // 실제 평문과 구분하기 위한 휴리스틱
+        return data.length() > 100 && containsBinaryCharacters(data);
+    }
+
+    /**
+     * 문자열에 바이너리 문자가 포함되어 있는지 확인
+     */
+    private boolean containsBinaryCharacters(String data) {
+        for (char c : data.toCharArray()) {
+            if (c < 32 && c != '\n' && c != '\r' && c != '\t') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 안전한 복호화 (복호화 실패 시 원본 반환)
+     * 
+     * 로깅이나 테스트 환경에서 사용
+     * 
+     * @param encryptedData 암호화된 데이터
+     * @return 복호화된 데이터 (실패 시 원본)
+     */
+    public String decryptSafe(String encryptedData) {
+        try {
+            return decrypt(encryptedData);
+        } catch (Exception e) {
+            log.warn("[CryptoUtil] 복호화 실패, 원본 반환. 오류: {}", e.getMessage());
+            return encryptedData;
+        }
+    }
+
+    /**
+     * 복호화 활성화 여부 확인
+     * 
+     * @return 복호화 활성화 여부
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/src/main/java/org/example/moono_backend/utils/CryptoUtil.java
+++ b/src/main/java/org/example/moono_backend/utils/CryptoUtil.java
@@ -64,6 +64,16 @@ public class CryptoUtil {
             Security.addProvider(new BouncyCastleProvider());
         }
     }
+    
+    @jakarta.annotation.PostConstruct
+    public void init() {
+        log.info("=".repeat(80));
+        log.info("[CryptoUtil] 초기화 완료");
+        log.info("[CryptoUtil] 복호화 활성화: {}", enabled);
+        log.info("[CryptoUtil] 시크릿 키 길이: {} bytes", secretKey != null ? secretKey.length() : 0);
+        log.info("[CryptoUtil] 시크릿 키 프리픽스: {}", secretKey != null && secretKey.length() > 10 ? secretKey.substring(0, 10) + "..." : "N/A");
+        log.info("=".repeat(80));
+    }
 
     /**
      * PostgreSQL pgp_sym_decrypt 호환 복호화
@@ -85,7 +95,8 @@ public class CryptoUtil {
         }
 
         try {
-            log.debug("[CryptoUtil] 복호화 시작. 데이터 길이: {}", encryptedData.length());
+            log.info("[CryptoUtil] 복호화 시작. 데이터 길이: {}, 키 길이: {}", 
+                encryptedData.length(), secretKey.length());
 
             // PostgreSQL bytea 형식 파싱
             byte[] encryptedBytes = parsePostgresByteA(encryptedData);


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #177 

### 작업 내용
### application.yml 파일 수정 
```
managment: 
   # 개인정보 암호화 설정 (PostgreSQL pgcrypto 호환)
      crypto:
        secret-key: ${CRYPTO_SECRET_KEY:실제 암호키로 변경}  # ⚠️ 실제 DB 암호화 키로 변경!
        enabled: true  

```
-> 이렇게 하셔야 적용됩니다 !

### 테스트 
복호화와 DLT 토픽 넘기는 것까지 확인하였습니다. 추가로 프론트에서 
<img width="743" height="468" alt="image" src="https://github.com/user-attachments/assets/a492c160-453b-4ef7-8315-8a7a807b72c9" />

#### 실제 작업 내용 
- [ ] CryptoUtil 클래스 생성 (PGP 복호화)
- [ ] EmailService 수정
```
[Producer]
DB (암호화) → Kafka (암호화) 📦
         ↓
[Consumer]
KafkaConsumerListener (암호화 유지) 📦
         ↓
BillingDispatchService (암호화 유지) 📦
         ↓
EmailService.sendBillingEmail()
         ↓
    ✅ decryptReceiverInfo() → 복호화
         ↓
    renderEmailSubject/Body (복호화된 데이터)
         ↓
    이메일 발송 (평문)
         ↓
   [실패 시]
         ↓
DLT Handler (암호화 유지) 📦
         ↓
EmailFailLog 저장 (암호화) 📦
```
<h2>이메일, sms 에러 처리 구조</h2>
<p><strong>EmailService (이메일 발송)</strong></p>

에러 유형 | ErrorCode | 설명
-- | -- | --
템플릿 렌더링 실패 | EMAIL_TEMPLATE_RENDER_FAILED | Handlebars 템플릿 처리 실패
복호화 실패 | EMAIL_DECRYPTION_FAILED | Receiver 정보 복호화 실패 ✅
수신자 오류 | EMAIL_INVALID_RECIPIENT | 수신자 정보 없음/잘못됨
이메일 발송 실패 | EMAIL_SEND_FAILED | 실제 이메일 API 호출 실패


<!-- notionvc: bd4cfbb7-72e0-4556-8bd3-9307a8006c9b -->
<p><strong>EmailFailLogService (SMS 발송)</strong></p>

에러 유형 | ErrorCode | 설명
-- | -- | --
JSON 파싱 실패 | JSON_PARSING_FAILED | payload 파싱 실패
복호화 실패 | SMS_DECRYPTION_FAILED | 전화번호 복호화 실패 ✅
SMS 발송 실패 | SMS_SEND_FAILED | 기타 SMS 관련 오류


<!-- notionvc: 875c2e2e-a733-40da-be87-5b7aff2cf559 -->

## 체크리스트
- [ ] 코드 작성 완료
- [ ] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [ ] 코드 스타일/컨벤션 확인


## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용