### PR TITLE
[MOONO-98] EmailFailLog Controller 페이징 처리 

### DIFF
--- a/src/main/java/org/example/moono_backend/api/EmailFailLogApiController.java
+++ b/src/main/java/org/example/moono_backend/api/EmailFailLogApiController.java
@@ -3,10 +3,11 @@ package org.example.moono_backend.api;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import org.example.moono_backend.domain.EmailFailLog;
-import org.example.moono_backend.domain.ParseStatus;
-import org.example.moono_backend.domain.SmsSendStatus;
 import org.example.moono_backend.service.EmailFailLogService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,49 +15,105 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/v1/emailFailLogs")
 public class EmailFailLogApiController {
 
     private final EmailFailLogService emailFailLogService;
 
-    @GetMapping("/emailFailLogs")
-    public Result findByPendingTarget() {
-        List<EmailFailLog> emailFailLogList = emailFailLogService.findSmsPendingTargets();
-        List<DetailEmailFailLogDto> detailEmailFailLogDtoList = emailFailLogList.stream()
-                .map(emailFailLog -> new DetailEmailFailLogDto(emailFailLog))
-                .collect(Collectors.toList());
-        return new Result(detailEmailFailLogDtoList);
+    /**
+     * 발송 실패 내역 조회 (페이징)
+     * 
+     * @param page 페이지 번호 (0부터 시작)
+     * @param size 페이지당 개수
+     * @return 실패 내역 리스트 (이름, 마스킹된 전화번호 포함)
+     */
+    @GetMapping
+    public FailureListResponse getFailures(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        Page<EmailFailLogService.EmailFailLogWithDetails> failurePage = 
+            emailFailLogService.findFailureListWithPaging(pageable);
+        
+        List<FailureItemDto> items = failurePage.getContent().stream()
+            .map(detail -> new FailureItemDto(
+                detail.getId(),
+                detail.getName(),
+                detail.getPhoneNumber(),
+                detail.getStatus()
+            ))
+            .collect(Collectors.toList());
+        
+        return new FailureListResponse(failurePage.getTotalElements(), items);
     }
 
-    @PostMapping("/emailFailLogs/{id}")
+    /**
+     * SMS 일괄 발송 (항상 성공 처리)
+     * 
+     * @return 발송 결과 통계
+     */
+    @PostMapping("/batch-sms")
+    public BatchSmsResponse sendBatchSms() {
+        EmailFailLogService.BatchSmsResult result = emailFailLogService.sendBatchSms();
+        
+        return new BatchSmsResponse(
+            result.getSuccessCount(),
+            result.getFailedCount(),
+            result.getTotalProcessed()
+        );
+    }
+
+    /**
+     * 개별 SMS 발송 (기존 API - 호환성 유지)
+     * 
+     * @param id EmailFailLog ID
+     * @return 처리 결과
+     */
+    @PostMapping("/{id}")
     public UpdateEmailFailLogResponse sendSmsById(@PathVariable("id") Long id) {
         emailFailLogService.update(id);
         return new UpdateEmailFailLogResponse(id);
     }
 
+    // ==================== 응답 DTO ====================
+    
+    /**
+     * 실패 내역 리스트 응답
+     */
     @Data
     @AllArgsConstructor
-    static class Result<T> {
-        private T data;
+    static class FailureListResponse {
+        private long totalCount;
+        private List<FailureItemDto> items;
     }
 
+    /**
+     * 실패 내역 개별 항목
+     */
     @Data
-    static class DetailEmailFailLogDto {
-        private Long emailFailLogId;
-        private String publicInfoId;
-        private SmsSendStatus smsSendStatus;
-        private ParseStatus parseStatus;
-        private String payload;
-
-        public DetailEmailFailLogDto(EmailFailLog emailFailLog) {
-            emailFailLogId = emailFailLog.getId();
-            publicInfoId = emailFailLog.getPublicInfoId();
-            smsSendStatus = emailFailLog.getSmsStatus();
-            parseStatus = emailFailLog.getParseStatus();
-            payload = emailFailLog.getPayload();
-        }
+    @AllArgsConstructor
+    static class FailureItemDto {
+        private Long id;
+        private String name;
+        private String phoneNumber;
+        private String status;
     }
 
+    /**
+     * 일괄 SMS 발송 응답
+     */
+    @Data
+    @AllArgsConstructor
+    static class BatchSmsResponse {
+        private int successCount;
+        private int failedCount;
+        private int totalProcessed;
+    }
+
+    /**
+     * 개별 SMS 발송 응답
+     */
     @Data
     @AllArgsConstructor
     static class UpdateEmailFailLogResponse {

--- a/src/main/java/org/example/moono_backend/api/EmailFailLogApiController.java
+++ b/src/main/java/org/example/moono_backend/api/EmailFailLogApiController.java
@@ -64,18 +64,6 @@ public class EmailFailLogApiController {
         );
     }
 
-    /**
-     * 개별 SMS 발송 (기존 API - 호환성 유지)
-     * 
-     * @param id EmailFailLog ID
-     * @return 처리 결과
-     */
-    @PostMapping("/{id}")
-    public UpdateEmailFailLogResponse sendSmsById(@PathVariable("id") Long id) {
-        emailFailLogService.update(id);
-        return new UpdateEmailFailLogResponse(id);
-    }
-
     // ==================== 응답 DTO ====================
     
     /**
@@ -109,14 +97,5 @@ public class EmailFailLogApiController {
         private int successCount;
         private int failedCount;
         private int totalProcessed;
-    }
-
-    /**
-     * 개별 SMS 발송 응답
-     */
-    @Data
-    @AllArgsConstructor
-    static class UpdateEmailFailLogResponse {
-        private Long emailFailLogId;
     }
 }

--- a/src/main/java/org/example/moono_backend/repository/EmailFailLogRepository.java
+++ b/src/main/java/org/example/moono_backend/repository/EmailFailLogRepository.java
@@ -3,7 +3,11 @@ package org.example.moono_backend.repository;
 import org.example.moono_backend.domain.EmailFailLog;
 import org.example.moono_backend.domain.ParseStatus;
 import org.example.moono_backend.domain.SmsSendStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -24,4 +28,25 @@ public interface EmailFailLogRepository extends JpaRepository<EmailFailLog, Long
     List<EmailFailLog> findBySmsStatus(SmsSendStatus smsSendStatus);
 
     List<EmailFailLog> findByParseStatusAndSmsStatus(ParseStatus parseStatus, SmsSendStatus smsSendStatus);
+
+    /**
+     * 페이징 처리된 실패 로그 조회
+     * 
+     * @param parseStatus 파싱 상태
+     * @param smsSendStatus SMS 발송 상태
+     * @param pageable 페이징 정보
+     * @return 페이징 처리된 EmailFailLog
+     */
+    Page<EmailFailLog> findByParseStatusAndSmsStatus(ParseStatus parseStatus, SmsSendStatus smsSendStatus, Pageable pageable);
+
+    /**
+     * 특정 년/월의 이메일 발송 실패 건수 조회 (SMS 전환 건수)
+     * 
+     * @param year  조회 년도
+     * @param month 조회 월 (1-12)
+     * @return 해당 년/월의 EmailFailLog 개수
+     */
+    @Query("SELECT COUNT(e) FROM EmailFailLog e " +
+           "WHERE YEAR(e.createdAt) = :year AND MONTH(e.createdAt) = :month")
+    Long countByYearAndMonth(@Param("year") int year, @Param("month") int month);
 }

--- a/src/main/java/org/example/moono_backend/service/EmailFailLogService.java
+++ b/src/main/java/org/example/moono_backend/service/EmailFailLogService.java
@@ -11,6 +11,8 @@ import org.example.moono_backend.exception.ErrorCode;
 import org.example.moono_backend.kafka.producer.BillingProducerMessageDto;
 import org.example.moono_backend.repository.EmailFailLogRepository;
 import org.example.moono_backend.utils.CryptoUtil;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +42,84 @@ public class EmailFailLogService {
 
     public List<EmailFailLog> findSmsPendingTargets() {
         return emailFailLogRepository.findByParseStatusAndSmsStatus(ParseStatus.SUCCESS, SmsSendStatus.PENDING);
+    }
+    
+    /**
+     * 페이징 처리된 실패 내역 조회 (이름, 마스킹된 전화번호 포함)
+     * 
+     * @param pageable 페이징 정보
+     * @return 페이징 처리된 EmailFailLog (payload 파싱 포함)
+     */
+    public Page<EmailFailLogWithDetails> findFailureListWithPaging(Pageable pageable) {
+        Page<EmailFailLog> failLogs = emailFailLogRepository.findByParseStatusAndSmsStatus(
+            ParseStatus.SUCCESS, 
+            SmsSendStatus.PENDING, 
+            pageable
+        );
+        
+        return failLogs.map(emailFailLog -> {
+            try {
+                // payload 파싱
+                BillingProducerMessageDto messageDto = objectMapper.readValue(
+                    emailFailLog.getPayload(), 
+                    BillingProducerMessageDto.class
+                );
+                
+                // 전화번호 복호화 후 마스킹
+                String phone = messageDto.getReceiver().getPhone();
+                String decryptedPhone = cryptoUtil.isEncrypted(phone) ? cryptoUtil.decrypt(phone) : phone;
+                String maskedPhone = maskPhone(decryptedPhone);
+                
+                return new EmailFailLogWithDetails(
+                    emailFailLog.getId(),
+                    messageDto.getReceiver().getName(),
+                    maskedPhone,
+                    emailFailLog.getSmsStatus().name()
+                );
+                
+            } catch (Exception e) {
+                log.error("[FAILURE-LIST] payload 파싱 실패. emailFailLogId={}", emailFailLog.getId(), e);
+                // 파싱 실패 시 기본값 반환
+                return new EmailFailLogWithDetails(
+                    emailFailLog.getId(),
+                    "파싱 실패",
+                    "***-****-****",
+                    emailFailLog.getSmsStatus().name()
+                );
+            }
+        });
+    }
+    
+    /**
+     * 일괄 SMS 발송 (항상 성공 처리)
+     * 
+     * @return 발송 결과 통계
+     */
+    @Transactional
+    public BatchSmsResult sendBatchSms() {
+        List<EmailFailLog> pendingLogs = emailFailLogRepository.findByParseStatusAndSmsStatus(
+            ParseStatus.SUCCESS, 
+            SmsSendStatus.PENDING
+        );
+        
+        int successCount = 0;
+        int failedCount = 0;
+        
+        for (EmailFailLog emailFailLog : pendingLogs) {
+            try {
+                // SMS 발송 처리 (기존 update 로직 재사용)
+                update(emailFailLog.getId());
+                successCount++;
+            } catch (Exception e) {
+                log.error("[BATCH-SMS] SMS 발송 실패. emailFailLogId={}", emailFailLog.getId(), e);
+                failedCount++;
+            }
+        }
+        
+        log.info("[BATCH-SMS] 일괄 발송 완료. 성공: {}, 실패: {}, 전체: {}", 
+            successCount, failedCount, pendingLogs.size());
+        
+        return new BatchSmsResult(successCount, failedCount, pendingLogs.size());
     }
 
     public EmailFailLog findById(Long id) {
@@ -130,5 +210,46 @@ public class EmailFailLogService {
         } else {
             return "*******" + lastFour;
         }
+    }
+    
+    /**
+     * 실패 내역 상세 정보 (이름, 마스킹된 전화번호 포함)
+     */
+    public static class EmailFailLogWithDetails {
+        private final Long id;
+        private final String name;
+        private final String phoneNumber;
+        private final String status;
+        
+        public EmailFailLogWithDetails(Long id, String name, String phoneNumber, String status) {
+            this.id = id;
+            this.name = name;
+            this.phoneNumber = phoneNumber;
+            this.status = status;
+        }
+        
+        public Long getId() { return id; }
+        public String getName() { return name; }
+        public String getPhoneNumber() { return phoneNumber; }
+        public String getStatus() { return status; }
+    }
+    
+    /**
+     * 일괄 SMS 발송 결과
+     */
+    public static class BatchSmsResult {
+        private final int successCount;
+        private final int failedCount;
+        private final int totalProcessed;
+        
+        public BatchSmsResult(int successCount, int failedCount, int totalProcessed) {
+            this.successCount = successCount;
+            this.failedCount = failedCount;
+            this.totalProcessed = totalProcessed;
+        }
+        
+        public int getSuccessCount() { return successCount; }
+        public int getFailedCount() { return failedCount; }
+        public int getTotalProcessed() { return totalProcessed; }
     }
 }


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #186 

## 작업 내용
<!-- 작업한 부분을 설명해주세요. -->
### EmailFailLogRepository.java (레포지토리)
- findByParseStatusAndSmsStatus() 메서드 추가 
  -  페이징 처리를 위한 메서드 추가 

### EmailFailLogService.java 
- findFailureListWithPaging() : 페이징 처리된 실패 내역 조회 
  -  payload에서 이름, 전화번호 파싱 및 복호화 
  - 전화번호 마스킹 처리 
  - EmailFailLogWithDetails DTO로 변환하여 반환 
 - sendBatchSms(): pending인 상태인 모든 실패 로그 조회 -> 상태를 success로 바꾸기 
    - 성공/ 실패 카운트를 BatchSmsResult 로 반환 

### EmailFailLogApiController.java 
- url 경로 변경 : → @RequestMapping("/api/v1/emailFailLogs")  // 변경
- 새로운 api 엔드 포인트 3개 
  - ① GET /api/v1/emailFailLogs - 실패 내역 조회 (페이징)
  - ② POST /api/v1/emailFailLogs/batch-sms - SMS 일괄 발송

## 주요 특징 
1. 페이징 처리 
- 기본값: 0페이지, 20개-> Spring Data의 Page, Pageable 사용 
2. 보안 처리 
- 전화번호 복호화는 서비스 내부에서 
- api 응답은 항상 마스킹된 번호 
3. 상태 관리 
- pending: sms 발송 대기 
- success: 발송 완료 
- 조회시 pending만, 발송 후 success로 변경 


## 체크리스트
- [ ] 코드 작성 완료
- [ ] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [ ] 코드 스타일/컨벤션 확인


## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용