### PR TITLE
[MOONO-102] 암호화 파싱 및 매핑 로직 복구

### DIFF
--- a/src/main/java/org/example/moono_backend/mapper/ForceBillingMapper.java
+++ b/src/main/java/org/example/moono_backend/mapper/ForceBillingMapper.java
@@ -79,7 +79,6 @@ public class ForceBillingMapper {
 
     // - Kafka에서 받은 BillingProducerMessageDto를
     // - 실제 이메일 발송에 사용하는 BillingConsumerMessageDto로 변환
-
     public BillingConsumerMessageDto toConsumerDtoFromProducer(BillingProducerMessageDto producerDto,
             RawDetailsDto rawDetails) {
         BillingConsumerMessageDto dto = new BillingConsumerMessageDto();
@@ -107,7 +106,6 @@ public class ForceBillingMapper {
         summary.setUsageFee(producerDto.getBillingSummary().getUsageFee());
         dto.setBillingSummary(summary);
 
-        // 4. Details 매핑 (기존에 작성하신 mapOverages, mapDiscounts 활용)
         BillingConsumerMessageDto.Details details = new BillingConsumerMessageDto.Details();
         details.setOverageItem(mapOverages(rawDetails.getOverages()));
         details.setDiscountItem(mapDiscounts(rawDetails.getDiscounts()));

--- a/src/main/java/org/example/moono_backend/service/message/BillingDispatchService.java
+++ b/src/main/java/org/example/moono_backend/service/message/BillingDispatchService.java
@@ -129,17 +129,14 @@ public class BillingDispatchService {
                 return ProcessResult.skip();
             }
         }
-        // 4. rawDetails 파싱 및 변환 (json 문자열을 RawDetailsDto로 파싱)
+        // 상세 내역 파싱
+        // messageDto.getRawDetails()에 담긴 JSON 문자열을 객체로 변환합니다.
         RawDetailsDto rawDetails = parseRawDetails(messageDto.getRawDetails(), billingId);
 
-        // 5. BillingProducerMessageDto를 BillingConsumerMessageDto로 변환
-        BillingConsumerMessageDto dispatchDto = convertToBillingDispatchDto(messageDto, rawDetails);
+        // 3. 매퍼 호출 (파싱된 rawDetails를 넘겨줌)
+        BillingConsumerMessageDto dispatchDto = forceBillingMapper.toConsumerDtoFromProducer(messageDto, rawDetails);
 
-        // 참고: 상태 업데이트는 이메일 발송 성공/실패 후에 처리
-        // - 성공: updateStatusToCompleted()
-        // - 실패: updateStatusToFailed()
         log.info("[Dispatch] DTO 변환 완료. 이메일 발송 준비. billingId: {}", billingId);
-
         return ProcessResult.send(dispatchDto);
     }
 

--- a/src/main/java/org/example/moono_backend/service/message/EmailService.java
+++ b/src/main/java/org/example/moono_backend/service/message/EmailService.java
@@ -205,7 +205,7 @@ public class EmailService {
      */
     private BillingConsumerMessageDto decryptReceiverInfo(BillingConsumerMessageDto dto) {
         String billingId = extractBillingId(dto);
-        
+
         try {
             BillingConsumerMessageDto decrypted = new BillingConsumerMessageDto();
 
@@ -220,22 +220,23 @@ public class EmailService {
 
             // Receiver 복호화 (암호화된 경우만)
             BillingConsumerMessageDto.Receiver receiver = new BillingConsumerMessageDto.Receiver();
-            
+
             String name = dto.getReceiver().getName();
             String email = dto.getReceiver().getEmail();
             String phone = dto.getReceiver().getPhone();
-            
+
             // 암호화 여부 체크 후 복호화
             receiver.setName(cryptoUtil.isEncrypted(name) ? cryptoUtil.decrypt(name) : name);
             receiver.setEmail(cryptoUtil.isEncrypted(email) ? cryptoUtil.decrypt(email) : email);
             receiver.setPhone(cryptoUtil.isEncrypted(phone) ? cryptoUtil.decrypt(phone) : phone);
-            
+
             decrypted.setReceiver(receiver);
 
-            log.info("[EmailService] Receiver 정보 처리 완료 (암호화: name={}, email={}, phone={}). billingId: {}", 
-                cryptoUtil.isEncrypted(name), cryptoUtil.isEncrypted(email), cryptoUtil.isEncrypted(phone), billingId);
+            log.info("[EmailService] Receiver 정보 처리 완료 (암호화: name={}, email={}, phone={}). billingId: {}",
+                    cryptoUtil.isEncrypted(name), cryptoUtil.isEncrypted(email), cryptoUtil.isEncrypted(phone),
+                    billingId);
             return decrypted;
-            
+
         } catch (Exception e) {
             log.error("[EmailService] Receiver 정보 복호화 실패. billingId: {}", billingId, e);
             throw new BaseException(ErrorCode.EMAIL_DECRYPTION_FAILED);


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #198 

## 작업 내용
<!-- 작업한 부분을 설명해주세요. -->

- [ ] 작업 1 ForceBillingMapper로 DTO 변환 구조를 단일화하면서 생겼던 rawDetail 복구
- [ ] 작업 2 개인정보 보호를 위해 암호화된 수신자 정보(이름, 이메일, 전화번호)를 DispatchService 단계에서 복호화하지 않고, 이메일 발송 직전(EmailService)까지 암호화된 상태 그대로 전달하도록 변경

## 체크리스트
- [ ] 코드 작성 완료
- [ ] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [ ] 코드 스타일/컨벤션 확인


## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용