### PR TITLE
[MOONO-102] 강제발송 관리자 목록 및 preview 에도 복호화 로직 추가

### DIFF
--- a/src/main/java/org/example/moono_backend/mapper/ForceBillingMapper.java
+++ b/src/main/java/org/example/moono_backend/mapper/ForceBillingMapper.java
@@ -12,6 +12,7 @@ import org.example.moono_backend.kafka.RawDetailsDto;
 import org.example.moono_backend.kafka.consumer.BillingConsumerMessageDto;
 import org.example.moono_backend.kafka.producer.BillingProducerMessageDto;
 import org.example.moono_backend.service.admin.BillingTypeConverter;
+import org.example.moono_backend.utils.CryptoUtil;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
@@ -25,11 +26,18 @@ public class ForceBillingMapper {
 
     private final ObjectMapper objectMapper;
     private final BillingTypeConverter typeConverter;
+    private final CryptoUtil cryptoUtil;
 
     // 1. 목록 조회용 변환 (ListItem)
     public ForceBillingDto.ListItem toListItem(Billing billing, MemberCredential member) {
-        String name = (member != null) ? member.getName() : "알 수 없음";
-        String email = (member != null) ? member.getEmail() : "";
+        String rawName = (member != null) ? member.getName() : "알 수 없음";
+        String rawEmail = (member != null) ? member.getEmail() : "";
+
+        String name = rawName; // 이름은 SQL상 평문이므로 그대로
+        // 이메일 복호화
+        String email = (member != null && cryptoUtil.isEncrypted(rawEmail))
+                ? cryptoUtil.decrypt(rawEmail)
+                : rawEmail;
 
         String formattedMonth = billing.getBillingDate().getYear() + "-" +
                 String.format("%02d", billing.getBillingDate().getMonthValue());
@@ -128,9 +136,17 @@ public class ForceBillingMapper {
 
         // Receiver
         BillingConsumerMessageDto.Receiver receiver = new BillingConsumerMessageDto.Receiver();
+
+        String decEmail = cryptoUtil.isEncrypted(member.getEmail())
+                ? cryptoUtil.decrypt(member.getEmail())
+                : member.getEmail();
+        String decPhone = cryptoUtil.isEncrypted(member.getPhoneNumber())
+                ? cryptoUtil.decrypt(member.getPhoneNumber())
+                : member.getPhoneNumber();
+
         receiver.setName(member.getName());
-        receiver.setEmail(member.getEmail());
-        receiver.setPhone(member.getPhoneNumber());
+        receiver.setEmail(decEmail);
+        receiver.setPhone(decPhone);
         dto.setReceiver(receiver);
 
         // Summary

--- a/src/main/java/org/example/moono_backend/service/admin/ForceBillingService.java
+++ b/src/main/java/org/example/moono_backend/service/admin/ForceBillingService.java
@@ -97,8 +97,8 @@ public class ForceBillingService {
 
         return ForceBillingDto.PreviewResponse.builder()
                 .billingId(billing.getId())
-                .userName(member.getName())
-                .userEmail(member.getEmail())
+                .userName(consumerDto.getReceiver().getName())
+                .userEmail(consumerDto.getReceiver().getEmail())
                 .billingMonth(consumerDto.getHeader().getBillingMonth())
                 .sendStatus(billing.getSendStatus().name())
                 .htmlSubject(subject)


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #199 

## 작업 내용
<!-- 작업한 부분을 설명해주세요. -->

- [ ] **작업 1** 관리자 페이지 미리보기 및 목록 조회 시 개인정보 복호화 적용
- [ ] **작업 2** 이메일 발송 프로세스 내 데이터 정합성 유지
`ForceBillingService.getPreview`에서 DB 엔티티(`member`)를 직접 참조하던 방식을
-> 매퍼가 생성한 consumerDto 참조 방식으로 변경하여, 
미리보기 화면과 실제 발송 내용이 일치하도록 개선했습니다.
- [ ] **작업 3** EmailService 렌더링 로직 최적화
`EmailService`가 데이터를 가공(재복호화)하지 않고 전달받은 DTO를 그대로 템플릿에 렌더링하게 하여, 중복 로직을 제거하고 데이터 왜곡 가능성을 차단했습니다.
## 체크리스트
- [ ] 코드 작성 완료
- [ ] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [ ] 코드 스타일/컨벤션 확인


## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용